### PR TITLE
docs: rctglm_methods documentation file updated a bit

### DIFF
--- a/R/rctglm_methods.R
+++ b/R/rctglm_methods.R
@@ -13,19 +13,19 @@
 #' @param ... additional arguments passed to methods
 #'
 #' @details
-#' `coef` just use the corresponding `glm` methods on the `glm`
-#' fit contained within the `rctglm` object. Thus, this function is a
-#' shortcuts to running `coef(x$glm)`.
-#'
-#' `summary` summarises information related to the estimand as well as
-#' the underlying GLM fit.
-#'
 #' `estimand` and `se_estimand` are methods for extracting the estimated
 #' estimand value as well as the standard error (SE) of the estimand.
 #' Extract the plug-in estimation of the estimand, found by using the
 #' estimand function on the predicted counterfactual means of each group.
 #' These functions are a shortcut to extract the list elements `estimand`
-#' and `se_estimand`of an `rctglm` class object.
+#' and `se_estimand` of an `rctglm` class object.
+#'
+#' `summary` summarises information related to the estimand as well as
+#' the underlying GLM fit.
+#'
+#' `coef` just use the corresponding `glm` methods on the `glm`
+#' fit contained within the `rctglm` object. Thus, this function is a
+#' shortcuts to running `coef(x$glm)`.
 #'
 #' @examples
 #' # Generate some data to showcase example
@@ -47,8 +47,8 @@
 #' print(ate)
 #' estimand(ate)
 #' se_estimand(ate)
-#' coef(ate)
 #' summary(ate)
+#' coef(ate)
 NULL
 
 #' @rdname rctglm_methods
@@ -76,8 +76,26 @@ print.rctglm <- function(x,
 
 #' @export
 #' @rdname rctglm_methods
-coef.rctglm <- function(object, ...) {
-  coef(object$glm)
+estimand <- function(object) {
+  UseMethod("estimand")
+}
+
+#' @export
+#' @rdname rctglm_methods
+estimand.rctglm <- function(object) {
+  object$estimand
+}
+
+#' @export
+#' @rdname rctglm_methods
+se_estimand <- function(object) {
+  UseMethod("se_estimand")
+}
+
+#' @export
+#' @rdname rctglm_methods
+se_estimand.rctglm <- function(object) {
+  object$se_estimand
 }
 
 #' @export
@@ -89,7 +107,7 @@ summary.rctglm <- function(object, ...) {
               estimand_fun = object$estimand_fun,
               group_indicator = object$group_indicator,
               call = object$call,
-              glm_summary = summary(object$glm))
+              glm_summary = summary(object$glm, ...))
 
   out <- structure(sum, class = "summary.rctglm")
 
@@ -97,7 +115,7 @@ summary.rctglm <- function(object, ...) {
 }
 
 #' @export
-#' @rdname rctglm_methods
+#' @noRd
 print.summary.rctglm <- function(
     x,
     digits = max(3L, getOption("digits") - 3L),
@@ -124,26 +142,8 @@ print.summary.rctglm <- function(
 
 #' @export
 #' @rdname rctglm_methods
-estimand <- function(x) {
-  UseMethod("estimand")
-}
-
-#' @export
-#' @rdname rctglm_methods
-estimand.rctglm <- function(x) {
-  x$estimand
-}
-
-#' @export
-#' @rdname rctglm_methods
-se_estimand <- function(x) {
-  UseMethod("se_estimand")
-}
-
-#' @export
-#' @rdname rctglm_methods
-se_estimand.rctglm <- function(x) {
-  x$se_estimand
+coef.rctglm <- function(object, ...) {
+  coef(object$glm)
 }
 
 print_estimand_info <- function(x,

--- a/man/rctglm_methods.Rd
+++ b/man/rctglm_methods.Rd
@@ -3,30 +3,27 @@
 \name{rctglm_methods}
 \alias{rctglm_methods}
 \alias{print.rctglm}
-\alias{coef.rctglm}
-\alias{summary.rctglm}
-\alias{print.summary.rctglm}
 \alias{estimand}
 \alias{estimand.rctglm}
 \alias{se_estimand}
 \alias{se_estimand.rctglm}
+\alias{summary.rctglm}
+\alias{coef.rctglm}
 \title{Methods for objects of class \code{rctglm}}
 \usage{
 \method{print}{rctglm}(x, digits = max(3L, getOption("digits") - 3L), ...)
 
-\method{coef}{rctglm}(object, ...)
+estimand(object)
+
+\method{estimand}{rctglm}(object)
+
+se_estimand(object)
+
+\method{se_estimand}{rctglm}(object)
 
 \method{summary}{rctglm}(object, ...)
 
-\method{print}{summary.rctglm}(x, digits = max(3L, getOption("digits") - 3L), ...)
-
-estimand(x)
-
-\method{estimand}{rctglm}(x)
-
-se_estimand(x)
-
-\method{se_estimand}{rctglm}(x)
+\method{coef}{rctglm}(object, ...)
 }
 \arguments{
 \item{x}{an object of class \code{rctglm}}
@@ -42,19 +39,19 @@ Methods mostly to extract information from model fit and inference. See
 details for more information on each method.
 }
 \details{
-\code{coef} just use the corresponding \code{glm} methods on the \code{glm}
-fit contained within the \code{rctglm} object. Thus, this function is a
-shortcuts to running \code{coef(x$glm)}.
-
-\code{summary} summarises information related to the estimand as well as
-the underlying GLM fit.
-
 \code{estimand} and \code{se_estimand} are methods for extracting the estimated
 estimand value as well as the standard error (SE) of the estimand.
 Extract the plug-in estimation of the estimand, found by using the
 estimand function on the predicted counterfactual means of each group.
 These functions are a shortcut to extract the list elements \code{estimand}
-and \code{se_estimand}of an \code{rctglm} class object.
+and \code{se_estimand} of an \code{rctglm} class object.
+
+\code{summary} summarises information related to the estimand as well as
+the underlying GLM fit.
+
+\code{coef} just use the corresponding \code{glm} methods on the \code{glm}
+fit contained within the \code{rctglm} object. Thus, this function is a
+shortcuts to running \code{coef(x$glm)}.
 }
 \examples{
 # Generate some data to showcase example
@@ -76,6 +73,6 @@ ate <- rctglm(formula = Y ~ .,
 print(ate)
 estimand(ate)
 se_estimand(ate)
-coef(ate)
 summary(ate)
+coef(ate)
 }


### PR DESCRIPTION
Rearranged order of function in usage as well as removing the `print.summary.rctglm` from the usage page. Made same rearrangement in the examples.