### PR TITLE
docs: Small documentation updates and fixed math rendering in pkgdown site

### DIFF
--- a/R/power.R
+++ b/R/power.R
@@ -19,7 +19,7 @@
 #' @details
 #' The formula in the case of an ANCOVA model with multiple covariate adjustement is:
 #'
-#' \eqn{
+#' \deqn{
 #' n=\frac{(1+r)^2}{r}\frac{(z_{1-\alpha/2}+z_{1-\beta})^2\sigma^2(1-R^2)}{(\beta_1-\beta_0-\Delta_s)^2}+\frac{(z_{1-\alpha/2})^2}{2}
 #' }
 #'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,5 +9,7 @@ NULL
 options::define_option(
   "verbose",
   default = 2,
-  desc = "`numeric` verbosity level specifying how much information should be printed to the user"
+  desc = "`numeric` verbosity level. Higher values means more information is
+  printed in console. A value of 0 means nothing is printed to console during
+  execution"
 )

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,11 @@
 url: https://nnpackages.github.io/PostCard/
 template:
   bootstrap: 5
+  includes:
+    in_header: |
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
+      <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+      <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
 
 reference:
 - title: Estimation of marginal effects in GLMs for two-armed randomised trials

--- a/man/fit_best_learner.Rd
+++ b/man/fit_best_learner.Rd
@@ -30,7 +30,9 @@ evaluating models}
 \item{learners}{a \code{list} of \code{tidymodels}. Default uses a combination of MARS, linear
 regression and boosted trees}
 
-\item{verbose}{\code{numeric} verbosity level specifying how much information should be printed to the user (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
+\item{verbose}{\code{numeric} verbosity level. Higher values means more information is
+printed in console. A value of 0 means nothing is printed to console during
+execution (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
 }
 \value{
 a trained \code{workflow}

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -4,7 +4,9 @@
 \alias{options}
 \title{PostCard Options}
 \arguments{
-\item{verbose}{\code{numeric} verbosity level specifying how much information should be printed to the user (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
+\item{verbose}{\code{numeric} verbosity level. Higher values means more information is
+printed in console. A value of 0 means nothing is printed to console during
+execution (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
 }
 \description{
 Internally used, package-specific options. All options will prioritize R options() values, and fall back to environment variables if undefined. If neither the option nor the environment variable is set, a default value is used.
@@ -24,7 +26,9 @@ options::opt(x, default, env = "PostCard")
 
 \describe{
 \item{verbose}{\describe{
-\code{numeric} verbosity level specifying how much information should be printed to the user\item{default: }{\preformatted{2}}
+\code{numeric} verbosity level. Higher values means more information is
+printed in console. A value of 0 means nothing is printed to console during
+execution\item{default: }{\preformatted{2}}
 \item{option: }{PostCard.verbose}
 \item{envvar: }{R_POSTCARD_VERBOSE (evaluated if possible, raw string otherwise)}
 }}

--- a/man/power_gs.Rd
+++ b/man/power_gs.Rd
@@ -45,7 +45,7 @@ a continuous outcome for unequal group sizes and unequal variances. Statistics i
 \details{
 The formula in the case of an ANCOVA model with multiple covariate adjustement is:
 
-\eqn{
+\deqn{
 n=\frac{(1+r)^2}{r}\frac{(z_{1-\alpha/2}+z_{1-\beta})^2\sigma^2(1-R^2)}{(\beta_1-\beta_0-\Delta_s)^2}+\frac{(z_{1-\alpha/2})^2}{2}
 }
 

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -45,7 +45,8 @@ make the "orientation" of the \code{estimand_fun} clear.}
 As a default, the ratio of 1's in data is used.}
 
 \item{estimand_fun}{a \code{function} with arguments \code{psi0} and \code{psi1} specifying
-the estimand or a \code{character} specifying a default estimand function. See
+the estimand. Alternative, specify "ate" or "rate_ratio" as a \code{character}
+to use one of the default estimand functions. See
 more details in the "Estimand" section of this documentation.}
 
 \item{estimand_fun_deriv0}{a \code{function} specifying the derivative of \code{estimand_fun} wrt. \code{psi0}. As a default
@@ -83,8 +84,12 @@ causal estimate of the estimand, as stated by articles XXXX.
 As noted in the description, \code{psi0} and \code{psi1} are the counterfactual means found by prediction using
 a fitted GLM in the binary groups defined by \code{group_indicator}.
 
-Default estimand functions can be specified via \code{"ate"} (taking the difference \code{psi1 - psi0}) and
-\code{"rate_ratio"} (taking the ratio \code{psi1 / psi0})
+Default estimand functions can be specified via \code{"ate"} (which uses the function
+\code{function(psi1, psi0) psi1-psi0}) and \code{"rate_ratio"} (which uses the function
+\code{function(psi1, psi0) psi1/psi0}). See more information on specifying the \code{estimand_fun}
+in section
+\href{https://nnpackages.github.io/PostCard/articles/more-details.html#specifying-any-estimand}{Specifying any estimand}
+in the vignette \code{vignette("more-details")}.
 
 As a default, the \code{Deriv} package is used to perform symbolic differentiation to find the derivatives of
 the \code{estimand_fun}.
@@ -93,6 +98,23 @@ the \code{estimand_fun}.
 \examples{
 # Generate some data to showcase example
 n <- 100
+dat_gaus <- glm_data(
+  1+1.5*X1+2*A,
+  X1 = rnorm(n),
+  A = rbinom(n, 1, .5),
+  family = gaussian()
+)
+
+# Fit the model
+ate <- rctglm(formula = Y ~ .,
+              group_indicator = A,
+              data = dat_gaus,
+              family = gaussian)
+
+# Pull information on estimand
+estimand(ate)
+
+## Another example with different family and specification of estimand_fun
 dat_binom <- glm_data(
   1+1.5*X1+2*A,
   X1 = rnorm(n),
@@ -100,13 +122,18 @@ dat_binom <- glm_data(
   family = binomial()
 )
 
-# Fit the model
-ate <- rctglm(formula = Y ~ .,
+rr <- rctglm(formula = Y ~ .,
+              group_indicator = A,
+              data = dat_binom,
+              family = binomial(),
+              estimand_fun = "rate_ratio")
+
+odds_ratio <- function(psi1, psi0) (psi1*(1-psi0))/(psi0*(1-psi1))
+or <- rctglm(formula = Y ~ .,
               group_indicator = A,
               data = dat_binom,
               family = binomial,
-              estimand_fun = "ate")
+              estimand_fun = odds_ratio)
 
-# Pull information on estimand
-estimand(ate)
+
 }

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -55,7 +55,9 @@ the algorithm will use symbolic differentiation to automatically find the deriva
 \item{estimand_fun_deriv1}{a \code{function} specifying the derivative of \code{estimand_fun} wrt. \code{psi1}. As a default
 the algorithm will use symbolic differentiation to automatically find the derivative from \code{estimand_fun}}
 
-\item{verbose}{\code{numeric} verbosity level specifying how much information should be printed to the user (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
+\item{verbose}{\code{numeric} verbosity level. Higher values means more information is
+printed in console. A value of 0 means nothing is printed to console during
+execution (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
 
 \item{...}{Additional arguments passed to \code{\link[stats:glm]{stats::glm()}}}
 }

--- a/man/rctglm_with_prognosticscore.Rd
+++ b/man/rctglm_with_prognosticscore.Rd
@@ -48,7 +48,8 @@ make the "orientation" of the \code{estimand_fun} clear.}
 As a default, the ratio of 1's in data is used.}
 
 \item{estimand_fun}{a \code{function} with arguments \code{psi0} and \code{psi1} specifying
-the estimand or a \code{character} specifying a default estimand function. See
+the estimand. Alternative, specify "ate" or "rate_ratio" as a \code{character}
+to use one of the default estimand functions. See
 more details in the "Estimand" section of this documentation.}
 
 \item{estimand_fun_deriv0}{a \code{function} specifying the derivative of \code{estimand_fun} wrt. \code{psi0}. As a default

--- a/man/rctglm_with_prognosticscore.Rd
+++ b/man/rctglm_with_prognosticscore.Rd
@@ -72,7 +72,9 @@ evaluating models}
 \item{learners}{a \code{list} of \code{tidymodels}. Default uses a combination of MARS, linear
 regression and boosted trees}
 
-\item{verbose}{\code{numeric} verbosity level specifying how much information should be printed to the user (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
+\item{verbose}{\code{numeric} verbosity level. Higher values means more information is
+printed in console. A value of 0 means nothing is printed to console during
+execution (Defaults to \code{2}, overwritable using option 'PostCard.verbose' or environment variable 'R_POSTCARD_VERBOSE')}
 }
 \value{
 an \code{rctglm_prog} and \code{rctglm} object. Corresponds to an \link{rctglm} fitted with a


### PR DESCRIPTION
Math rendering in pkgdown is broken right now, so used solution from https://github.com/r-lib/pkgdown/issues/2704#issuecomment-2307055568.

### Documentation
Clarified use of `estimand_fun` a bit more as well as the `verbose` argument.