### PR TITLE
feat: `cv_variance` argument in `rctglm` now performs stratified sampling for cross validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     rsample,
     stats,
     stringr,
+    tidyselect,
     tune,
     utils,
     workflowsets,

--- a/R/rctglm_utils.R
+++ b/R/rctglm_utils.R
@@ -1,9 +1,9 @@
 # Modify data to have the same value of a group identifier and then predict
 predict_counterfactual_mean <- function(model,
-                                         group_indicator_name,
-                                         group_val,
-                                         newdata = NULL,
-                                         data = NULL) {
+                                        group_indicator_name,
+                                        group_val,
+                                        newdata = NULL,
+                                        data = NULL) {
   if (is.null(data)) data <- model$data
   if (is.null(newdata)) newdata <- data
   newdata_same_group_val <- newdata |>
@@ -22,12 +22,16 @@ predict_counterfactual_means <- function(model,
                                          newdata = NULL,
                                          data = NULL) {
   args <- as.list(environment())
-  counterfactual_preds <- sapply(c(0,1), function(x) {
-    do.call(
-      predict_counterfactual_mean,
-      c(args, list(group_val = x))
-    )
-  }) %>%
+  counterfactual_preds <- sapply(
+    c(0,1),
+    function(x) {
+      do.call(
+        predict_counterfactual_mean,
+        c(args, list(group_val = x))
+      )
+    },
+    simplify = FALSE
+  ) %>%
     as.data.frame() %>%
     stats::setNames(c("psi0", "psi1"))
 
@@ -42,4 +46,53 @@ default_estimand_funs <- function(default = c("ate", "rate_ratio")) {
          ate = function(psi1, psi0) psi1-psi0,
          rate_ratio = function(psi1, psi0) psi1/psi0
   )
+}
+
+# Do cross validation splits, fit models to training data and predict on test
+# data to obtain out-of-sample predictions
+oos_fitted.values_counterfactual <- function(
+    data,
+    group_indicator_name,
+    full_model.args_glm,
+    cv_folds_variance = 5
+) {
+  folds <- rsample::vfold_cv(
+    data,
+    v = cv_folds_variance,
+    strata = tidyselect::all_of(group_indicator_name)
+  )
+  train_test_folds <- lapply(
+    folds$splits,
+    extract_train_test
+  )
+
+  out <- lapply(train_test_folds, function(x) {
+    args_glm_copy <- full_model.args_glm
+    args_glm_copy$data <- x$train
+
+    model_train <- do.call(glm, args = args_glm_copy)
+
+    preds <- predict_counterfactual_means(
+      model = model_train,
+      group_indicator_name = group_indicator_name,
+      newdata = x$test
+    )
+    return(preds)
+  }) %>%
+    dplyr::bind_rows()
+
+  out$rowname <- row.names(out)
+  out <- out %>%
+    dplyr::arrange(as.numeric(.data$rowname))
+
+  return(out)
+}
+
+
+# x of class c("vfold_split", "rsplit"). Result of rsample::vfold_cv
+extract_train_test <- function(x) {
+  train_data <- x$data[x$in_id, ]
+  out_id <- setdiff(1:nrow(x$data), x$in_id)
+  test_data <- x$data[out_id, ]
+  return(list(train = train_data, test = test_data))
 }

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -107,7 +107,8 @@ is 0 and 1, respectively. Taking means of these predictions produce the \emph{co
 The variance of the estimand is found by taking the variance of the influence function of the estimand.
 If \code{cv_variance} is \code{TRUE}, then the counterfactual predictions for each observation (which are
 used to calculate the value of the influence function) is obtained as out-of-sample (OOS) predictions
-using cross validation with number of folds specified by \code{cv_folds}.
+using cross validation with number of folds specified by \code{cv_folds}. The cross validation splits
+are performed using stratified sampling with \code{group_indicator} as the \code{strata} argument in \link[rsample:vfold_cv]{rsample::vfold_cv}.
 
 This method of inference using plug-in estimation and influence functions for the variance produces a
 causal estimate of the estimand, as stated by articles XXXX.

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -12,7 +12,7 @@
       estimand(ate_with_cv)
     Output
         Estimate Std. Error
-      1 1.762089  0.1928675
+      1 1.762089   0.189105
 
 # `estimand_fun_derivX` can be left as NULL or specified manually
 

--- a/tests/testthat/_snaps/rctglm_methods.md
+++ b/tests/testthat/_snaps/rctglm_methods.md
@@ -4,7 +4,7 @@
       est1
     Output
         Estimate Std. Error
-      1 1.325113   1.130491
+      1 1.325113   1.269777
 
 ---
 

--- a/tests/testthat/_snaps/rctglm_utils.md
+++ b/tests/testthat/_snaps/rctglm_utils.md
@@ -1,0 +1,39 @@
+# `oos_fitted.values_counterfactual` snapshot test
+
+    Code
+      oos
+    Output
+         psi0 psi1 rowname
+      1     1    1       1
+      2     2    2       2
+      3     3    3       3
+      4     4    4       4
+      5     5    5       5
+      6     6    6       6
+      7     7    7       7
+      8     8    8       8
+      9     9    9       9
+      10   10   10      10
+
+# `extract_train_test` returns list of train and test data
+
+    Code
+      list_of_train_test
+    Output
+      $train
+          Y  X A
+      2   2  2 0
+      3   3  3 0
+      4   4  4 0
+      5   5  5 0
+      6   6  6 1
+      7   7  7 1
+      8   8  8 1
+      9   9  9 1
+      10 10 10 1
+      
+      $test
+        Y X A
+      1 1 1 0
+      
+

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -50,5 +50,5 @@
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.017
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 3.975
       Estimand function r: psi1 - psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 1.957 (0.2025)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 1.957 (0.2052)
 

--- a/tests/testthat/test-rctglm_utils.R
+++ b/tests/testthat/test-rctglm_utils.R
@@ -106,3 +106,44 @@ test_that("`default_estimand_funs` error when giving non-legal default", {
   expect_error(default_estimand_funs("test"),
                "should be one of")
 })
+
+# oos_fitted.values_counterfactual
+test_that("`oos_fitted.values_counterfactual` snapshot test", {
+  dat <- data.frame(
+    Y = 1:10,
+    X = 1:10,
+    A = c(rep(0, 5), rep(1, 5)
+    )
+  )
+
+  args_glm <- list(
+    formula = formula(Y ~ X + A)
+  )
+
+  oos <- oos_fitted.values_counterfactual(
+    data = dat,
+    group_indicator_name = "A",
+    full_model.args_glm = args_glm
+  )
+  expect_named(oos, c("psi0", "psi1", "rowname"))
+  expect_s3_class(oos, "data.frame")
+  expect_snapshot(oos)
+})
+
+# extract_train_test
+test_that("`extract_train_test` returns list of train and test data", {
+  dat <- data.frame(
+    Y = 1:10,
+    X = 1:10,
+    A = c(rep(0, 5), rep(1, 5)
+    )
+  )
+
+  withr::local_seed(42)
+  folds <- rsample::vfold_cv(dat)
+  single_fold <- folds$splits[[1]]
+  list_of_train_test <- extract_train_test(single_fold)
+  expect_type(list_of_train_test, "list")
+  expect_named(list_of_train_test, c("train", "test"))
+  expect_snapshot(list_of_train_test)
+})


### PR DESCRIPTION
Also introduced the tidyselect package to avoid deprecation warning messages.