### PR TITLE
fix: fixed order of arguments in derivative functions

### DIFF
--- a/R/influence_function_utils.R
+++ b/R/influence_function_utils.R
@@ -56,12 +56,12 @@ if_counterfactual_mean_glm <- function(response_variable,
                                        group_indicator,
                                        counterfactual_pred,
                                        group_allocation_prob = 1/2
-                                       ) {
+) {
   counterfactual_mean <- mean(counterfactual_pred)
 
   group_indicator/group_allocation_prob *
-     (response_variable - counterfactual_pred) +
-     (counterfactual_pred - counterfactual_mean)
+    (response_variable - counterfactual_pred) +
+    (counterfactual_pred - counterfactual_mean)
 }
 
 #' Evaluate the influence function of a marginal effect in a GLM model
@@ -107,10 +107,14 @@ if_marginaleffect <- function(response_variable,
   counterfactual_mean0 <- mean(counterfactual_pred0)
   counterfactual_mean1 <- mean(counterfactual_pred1)
 
-  if_estimand <- estimand_fun_deriv1(counterfactual_mean0,
-                                     counterfactual_mean1) * counterfactual_mean_IF1 +
-    estimand_fun_deriv0(counterfactual_mean0,
-                        counterfactual_mean1) * counterfactual_mean_IF0
+  if_estimand <- estimand_fun_deriv1(
+    psi1 = counterfactual_mean1,
+    psi0 = counterfactual_mean0
+  ) * counterfactual_mean_IF1 +
+    estimand_fun_deriv0(
+      psi1 = counterfactual_mean1,
+      psi0 = counterfactual_mean0
+    ) * counterfactual_mean_IF0
 
   return(if_estimand)
 }

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -67,5 +67,5 @@
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.609
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 64.14
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.04211)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.4543)
 


### PR DESCRIPTION
 When calculating the marginal effect influence function `if_marginaleffect`, derivatives of `estimand_fun` are calculated. I have fixed naming the arguments when calling these functions to make sure the mapping of counterfactual means are correct.