### PR TITLE
fix: Remembered to use cv_variance argument in rctglm_with_prognosticscore function

### DIFF
--- a/R/rctglm_with_prognosticscore.R
+++ b/R/rctglm_with_prognosticscore.R
@@ -137,6 +137,8 @@ rctglm_with_prognosticscore <- function(
     estimand_fun = estimand_fun,
     estimand_fun_deriv0 = estimand_fun_deriv0,
     estimand_fun_deriv1 = estimand_fun_deriv1,
+    cv_variance = cv_variance,
+    cv_variance_folds = cv_variance_folds,
     verbose = verbose,
     ...
   )

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -1,18 +1,18 @@
 # `rctglm` snapshot tests
 
     Code
-      estimand(ate_wo_cv)
-    Output
-        Estimate Std. Error
-      1 1.762089  0.1885315
-
----
-
-    Code
       estimand(ate_with_cv)
     Output
         Estimate Std. Error
       1 1.762089  0.1932432
+
+---
+
+    Code
+      estimand(ate_wo_cv)
+    Output
+        Estimate Std. Error
+      1 1.762089  0.1885315
 
 # `estimand_fun_derivX` can be left as NULL or specified manually
 

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -38,24 +38,16 @@
 ---
 
     Code
-      ate_wo_cvvariance
-    Output
-      
-      Object of class rctglm_prog 
-      
-      Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = gaussian(), 
-          data = dat_treat, group_indicator = A, estimand_fun = "ate", 
-          cv_variance = FALSE, data_hist = dat_notreat, verbose = 0)
-      
-      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.017
-      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 3.975
-      Estimand function r: psi1 - psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 1.957 (0.2076)
+      ate_wo_cvvariance <- withr::with_seed(42, {
+        rctglm_with_prognosticscore(formula = Y ~ ., group_indicator = A, data = dat_treat,
+        family = gaussian(), estimand_fun = "ate", data_hist = dat_notreat,
+        cv_variance = FALSE, verbose = 0)
+      })
 
 ---
 
     Code
-      ate_pois
+      rr_pois
     Output
       
       Object of class rctglm_prog 
@@ -68,4 +60,21 @@
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 64.14
       Estimand function r: psi1/psi0
       Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.456)
+
+---
+
+    Code
+      rr_nb
+    Output
+      
+      Object of class rctglm_prog 
+      
+      Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = MASS::negative.binomial(2), 
+          data = dat_treat_pois, group_indicator = A, estimand_fun = "rate_ratio", 
+          data_hist = dat_notreat_pois, verbose = 0)
+      
+      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.478
+      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 65.41
+      Estimand function r: psi1/psi0
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.715 (0.4847)
 


### PR DESCRIPTION
Fix in relation to implementation in #21.