### PR TITLE
feat: Changed formula in glm_data to include response

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     tidyselect,
     tune,
     utils,
+    withr,
     workflowsets,
     xgboost,
     yardstick
@@ -36,8 +37,7 @@ Suggests:
     MASS,
     ranger,
     rmarkdown,
-    testthat (>= 3.0.0),
-    withr
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/R/create_example_data.R
+++ b/R/create_example_data.R
@@ -6,50 +6,90 @@
 #' simulate the response with this mean from the generating function according
 #' to the chosen family.
 #'
-#' @param formula_eta an `expression` specifying how
-#' to generate the mean of the response (together with the inverse link from `family`)
+#' @inheritParams rctglm
 #' @param ... a `data.frame` with columns corresponding to variables used
-#' in `formula_eta`, a named `list` of those variables, or individually provided
+#' in `formula`, a named `list` of those variables, or individually provided
 #' named arguments of variables
 #' from
 #' @param family the `family` of the response. this can be a `character`
 #' string naming a family function, a family `function` or the result of
 #' a `call` to a family function
 #' @param family_args a named `list` with values of arguments passed to
-#' family relevant r<family_name> function for simulating the data
-#' @param response_name a `character` giving the name of the simulated response
+#' family relevant `r<family_name>` function for simulating the data
 #'
 #' @returns a `data.frame`
 #' @export
 #'
 #' @examples
 #' # Generate a gaussian response from a single covariate
-#' glm_data(1+2*x1,
+#' glm_data(Y ~ 1+2*x1,
 #'                 x1 = rnorm(10))
 #'
-#' # Generate a gaussian response from a single covariate with
-#' # non-linear effects
-#' glm_data(1+2*abs(sin(x1)),
-#'                 x1 = runif(10, min = -2, max = 2))
+#' # Generate a gaussian response from a single covariate with non-linear
+#' # effects. Specify that the response should have standard deviation sqrt(3)
+#' glm_data(Y ~ 1+2*abs(sin(x1)),
+#'                 x1 = runif(10, min = -2, max = 2),
+#'                 family_args = list(sd = sqrt(3)))
 #'
 #' # Generate a negative binomial response
-#' glm_data(1+2*x1-x2,
+#' glm_data(Y ~ 1+2*x1-x2,
 #'                 x1 = rnorm(10),
 #'                 x2 = rgamma(10, shape = 2),
 #'                 family = MASS::negative.binomial(2))
 #'
 #' # Provide variables as a list/data.frame
-#' glm_data(1+2*x1-x2,
+#' glm_data(resp ~ 1+2*x1-x2,
 #'                 data.frame(
 #'                   x1 = rnorm(10),
 #'                   x2 = rgamma(10, shape = 2)
 #'                 ),
 #'                 family = MASS::negative.binomial(2))
-glm_data <- function(formula_eta,
-                            ...,
-                            family = gaussian(),
-                            family_args = list(sd = 1),
-                            response_name = "Y") {
+glm_data <- function(formula,
+                     ...,
+                     family = gaussian(),
+                     family_args = list(sd = 1)) {
+  family = check_family(family)
+
+  data_list <- list(...)
+  if (length(data_list) == 0) cli::cli_abort("You need to specify columns to generate data from")
+  # if (length(data_list) == 0 && is.null(formula)) {
+  #   data_list <- list(A = rbinom(10, size = 1, prob = .5),
+  #                     X1 = rnorm(10))
+  #   formula <- expression(A + X1)
+  # }
+  data <- as.data.frame(data_list)
+  n_obs <- nrow(data)
+
+  rhs_of_formula <- get_explanatory_from_formula(formula)
+  cols_env <- rlang::new_environment(
+    data = data
+    # , parent = parent.frame()
+  )
+  linear_predictor <- withr::with_environment(
+    env = cols_env,
+    code = eval(parse(text = rhs_of_formula))
+  )
+  mu <- family$linkinv(linear_predictor)
+
+  args_to_rfun <- c(list(n = n_obs,
+                         mu = mu,
+                         family = family),
+                    family_args)
+  y <- do.call(generate_from_family, args_to_rfun)
+
+  response_name <- get_response_from_formula(formula)
+  out <- data %>%
+    dplyr::mutate("{response_name}" := y,
+                  .before = dplyr::everything())
+
+  return(out)
+}
+
+glm_data_old <- function(formula_eta,
+                         ...,
+                         family = gaussian(),
+                         family_args = list(sd = 1),
+                         response_name = "Y") {
   family = check_family(family)
 
   data_list <- list(...)

--- a/R/create_example_data.R
+++ b/R/create_example_data.R
@@ -60,15 +60,12 @@ glm_data <- function(formula,
   data <- as.data.frame(data_list)
   n_obs <- nrow(data)
 
-  rhs_of_formula <- get_explanatory_from_formula(formula)
   cols_env <- rlang::new_environment(
-    data = data
-    # , parent = parent.frame()
+    data = data,
+    parent = parent.frame()
   )
-  linear_predictor <- withr::with_environment(
-    env = cols_env,
-    code = eval(parse(text = rhs_of_formula))
-  )
+  rhs_of_formula <- formula[[3]]
+  linear_predictor <- eval(rhs_of_formula, envir = cols_env)
   mu <- family$linkinv(linear_predictor)
 
   args_to_rfun <- c(list(n = n_obs,

--- a/R/fit_best_learner.R
+++ b/R/fit_best_learner.R
@@ -13,13 +13,13 @@
 #' # Generate some synthetic 2-armed RCT data along with historical controls
 #' n <- 100
 #' dat_rct <- glm_data(
-#'   1+2*x1+3*a,
+#'   Y ~ 1+2*x1+3*a,
 #'   x1 = rnorm(n, 2),
 #'   a = rbinom (n, 1, .5),
 #'   family = gaussian()
 #' )
 #' dat_hist <- glm_data(
-#'   1+2*x1,
+#'   Y ~ 1+2*x1,
 #'   x1 = rnorm(n, 2),
 #'   family = gaussian()
 #' )

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -142,6 +142,7 @@ rctglm <- function(formula,
   group_indicator <- rlang::enquo(group_indicator)
   args <- as.list(environment())
   cal <- match.call()
+  formula <- check_formula(formula)
 
   ind_expr <- rlang::quo_get_expr(group_indicator)
   called_within_prognosticscore <- ind_expr == "group_indicator"

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -86,7 +86,7 @@
 #' # Generate some data to showcase example
 #' n <- 100
 #' dat_gaus <- glm_data(
-#'   1+1.5*X1+2*A,
+#'   Y ~ 1+1.5*X1+2*A,
 #'   X1 = rnorm(n),
 #'   A = rbinom(n, 1, .5),
 #'   family = gaussian()
@@ -103,7 +103,7 @@
 #'
 #' ## Another example with different family and specification of estimand_fun
 #' dat_binom <- glm_data(
-#'   1+1.5*X1+2*A,
+#'   Y ~ 1+1.5*X1+2*A,
 #'   X1 = rnorm(n),
 #'   A = rbinom(n, 1, .5),
 #'   family = binomial()

--- a/R/rctglm_methods.R
+++ b/R/rctglm_methods.R
@@ -26,7 +26,7 @@
 #' # Generate some data to showcase example
 #' n <- 100
 #' dat_binom <- glm_data(
-#'   1+1.5*X1+2*A,
+#'   Y ~ 1+1.5*X1+2*A,
 #'   X1 = rnorm(n),
 #'   A = rbinom(n, 1, .5),
 #'   family = binomial()

--- a/R/rctglm_prog_methods.R
+++ b/R/rctglm_prog_methods.R
@@ -18,13 +18,13 @@
 #' W1 <- runif(n, min = -2, max = 2)
 #'
 #' dat_treat <- glm_data(
-#'   b0+b1*abs(sin(W1))+b2*A,
+#'   Y ~ b0+b1*abs(sin(W1))+b2*A,
 #'   W1 = W1,
 #'   A = rbinom (n, 1, .5)
 #' )
 #'
 #' dat_notreat <- glm_data(
-#'   b0+b1*abs(sin(W1)),
+#'   Y ~ b0+b1*abs(sin(W1)),
 #'   W1 = W1
 #' )
 #'

--- a/R/rctglm_with_prognosticscore.R
+++ b/R/rctglm_with_prognosticscore.R
@@ -46,13 +46,13 @@
 #' W1 <- runif(n, min = -2, max = 2)
 #'
 #' dat_treat <- glm_data(
-#'   b0+b1*abs(sin(W1))+b2*A,
+#'   Y ~ b0+b1*abs(sin(W1))+b2*A,
 #'   W1 = W1,
 #'   A = rbinom (n, 1, .5)
 #' )
 #'
 #' dat_notreat <- glm_data(
-#'   b0+b1*abs(sin(W1)),
+#'   Y ~ b0+b1*abs(sin(W1)),
 #'   W1 = W1
 #' )
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,10 +28,17 @@ formula_to_str <- function(formula) {
   deparse(formula)
 }
 
+# Extract right hand side of formula as string
+get_explanatory_from_formula <- function(formula) {
+  formula <- check_formula(formula)
+  formula <- formula_to_str(formula)
+  rhs_oftilde <- gsub(".*~\\s*", "", formula)
+  return(rhs_oftilde)
+}
+
 # Extract response from formula to
 get_response_from_formula <- function(formula) {
   formula <- check_formula(formula)
-
   formula <- formula_to_str(formula)
   lhs_oftilde <- gsub("\\s*~.*", "", formula)
   return(lhs_oftilde)

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,14 +28,6 @@ formula_to_str <- function(formula) {
   deparse(formula)
 }
 
-# Extract right hand side of formula as string
-get_explanatory_from_formula <- function(formula) {
-  formula <- check_formula(formula)
-  formula <- formula_to_str(formula)
-  rhs_oftilde <- gsub(".*~\\s*", "", formula)
-  return(rhs_oftilde)
-}
-
 # Extract response from formula to
 get_response_from_formula <- function(formula) {
   formula <- check_formula(formula)

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,6 +14,16 @@ deparse_fun_body <- function(fun) {
 
 #' Transform character or family function to a call
 check_formula <- function(formula) {
+  tryCatch(
+    formula,
+    error = function(e) cli::cli_abort(
+      c(
+        "{.arg formula} was not of class `formula` or could not be coerced to one.",
+        i = "This usually means you did not include a response followed by a `~`.",
+        i = "Did you mean `Y ~ `formula``?"
+      )
+    )
+  )
   if (is.character(formula)) {
     formula <- formula(formula)
   }
@@ -26,6 +36,10 @@ check_formula <- function(formula) {
 
 formula_to_str <- function(formula) {
   deparse(formula)
+}
+
+formula_to_str2 <- function(formula) {
+  rlang::as_label(rlang::enquo(formula))
 }
 
 # Extract response from formula to

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ b2 <- 2
 
 # Simulate data with a non-linear effect
 dat_treat <- glm_data(
-  b0+b1*sin(W)^2+b2*A,
+  Y ~ b0+b1*sin(W)^2+b2*A,
   W = runif(n, min = -2, max = 2),
   A = rbinom(n, 1, .5),
   family = gaussian() # Default value
@@ -122,7 +122,7 @@ Allowing the use of complex non-linear models to create such a prognostic score 
 We simulate some historical data to showcase the use of this function as well:
 ```{r hist-data}
 dat_notreat <- glm_data(
-  b0+b1*sin(W)^2,
+  Y ~ b0+b1*sin(W)^2,
   W = runif(n, min = -2, max = 2),
   family = gaussian # Default value
 )

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ b2 <- 2
 
 # Simulate data with a non-linear effect
 dat_treat <- glm_data(
-  b0+b1*sin(W)^2+b2*A,
+  Y ~ b0+b1*sin(W)^2+b2*A,
   W = runif(n, min = -2, max = 2),
   A = rbinom(n, 1, .5),
   family = gaussian() # Default value
@@ -104,7 +104,7 @@ ate
 #> Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.776
 #> Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 4.867
 #> Estimand function r: psi1 - psi0
-#> Estimand (r(psi_1, psi_0)) estimate (SE): 2.091 (0.09225)
+#> Estimand (r(psi_1, psi_0)) estimate (SE): 2.091 (0.09236)
 ```
 
 ### Structure of `rctglm` and methods for extracting entities
@@ -133,7 +133,7 @@ Thus, methods available are:
 # "estimate" also available as alternative to just "est"
 est(ate)
 #>   Estimate Std. Error
-#> 1 2.091095 0.09224543
+#> 1 2.091095 0.09235538
 coef(ate)
 #> (Intercept)           A           W         A:W 
 #>  2.77585401  2.09122279  0.02364106  0.04961895
@@ -160,7 +160,7 @@ well:
 
 ``` r
 dat_notreat <- glm_data(
-  b0+b1*sin(W)^2,
+  Y ~ b0+b1*sin(W)^2,
   W = runif(n, min = -2, max = 2),
   family = gaussian # Default value
 )
@@ -198,10 +198,10 @@ ate_prog
 #> Call:  rctglm_with_prognosticscore(formula = Y ~ A * W, family = gaussian(link = "identity"), 
 #>     data = dat_treat, group_indicator = A, data_hist = dat_notreat)
 #> 
-#> Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.828
-#> Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 4.819
+#> Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.824
+#> Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 4.822
 #> Estimand function r: psi1 - psi0
-#> Estimand (r(psi_1, psi_0)) estimate (SE): 1.992 (0.06445)
+#> Estimand (r(psi_1, psi_0)) estimate (SE): 1.999 (0.0639)
 ```
 
 It’s evident that in this case where there is a non-linear relationship

--- a/man/fit_best_learner.Rd
+++ b/man/fit_best_learner.Rd
@@ -42,13 +42,13 @@ Find the best learner in terms of RMSE among specified learners using cross vali
 # Generate some synthetic 2-armed RCT data along with historical controls
 n <- 100
 dat_rct <- glm_data(
-  1+2*x1+3*a,
+  Y ~ 1+2*x1+3*a,
   x1 = rnorm(n, 2),
   a = rbinom (n, 1, .5),
   family = gaussian()
 )
 dat_hist <- glm_data(
-  1+2*x1,
+  Y ~ 1+2*x1,
   x1 = rnorm(n, 2),
   family = gaussian()
 )

--- a/man/glm_data.Rd
+++ b/man/glm_data.Rd
@@ -4,20 +4,15 @@
 \alias{glm_data}
 \title{Generate data simulated from a GLM}
 \usage{
-glm_data(
-  formula_eta,
-  ...,
-  family = gaussian(),
-  family_args = list(sd = 1),
-  response_name = "Y"
-)
+glm_data(formula, ..., family = gaussian(), family_args = list(sd = 1))
 }
 \arguments{
-\item{formula_eta}{an \code{expression} specifying how
-to generate the mean of the response (together with the inverse link from \code{family})}
+\item{formula}{an object of class "formula" (or one that can be coerced to that class):
+a symbolic description of the model to be fitted. The details of model specification are
+given under ‘Details’ in the \link{glm} documentation.}
 
 \item{...}{a \code{data.frame} with columns corresponding to variables used
-in \code{formula_eta}, a named \code{list} of those variables, or individually provided
+in \code{formula}, a named \code{list} of those variables, or individually provided
 named arguments of variables
 from}
 
@@ -26,9 +21,7 @@ string naming a family function, a family \code{function} or the result of
 a \code{call} to a family function}
 
 \item{family_args}{a named \code{list} with values of arguments passed to
-family relevant r<family_name> function for simulating the data}
-
-\item{response_name}{a \code{character} giving the name of the simulated response}
+family relevant \verb{r<family_name>} function for simulating the data}
 }
 \value{
 a \code{data.frame}
@@ -42,22 +35,23 @@ to the chosen family.
 }
 \examples{
 # Generate a gaussian response from a single covariate
-glm_data(1+2*x1,
+glm_data(Y ~ 1+2*x1,
                 x1 = rnorm(10))
 
-# Generate a gaussian response from a single covariate with
-# non-linear effects
-glm_data(1+2*abs(sin(x1)),
-                x1 = runif(10, min = -2, max = 2))
+# Generate a gaussian response from a single covariate with non-linear
+# effects. Specify that the response should have standard deviation sqrt(3)
+glm_data(Y ~ 1+2*abs(sin(x1)),
+                x1 = runif(10, min = -2, max = 2),
+                family_args = list(sd = sqrt(3)))
 
 # Generate a negative binomial response
-glm_data(1+2*x1-x2,
+glm_data(Y ~ 1+2*x1-x2,
                 x1 = rnorm(10),
                 x2 = rgamma(10, shape = 2),
                 family = MASS::negative.binomial(2))
 
 # Provide variables as a list/data.frame
-glm_data(1+2*x1-x2,
+glm_data(resp ~ 1+2*x1-x2,
                 data.frame(
                   x1 = rnorm(10),
                   x2 = rgamma(10, shape = 2)

--- a/man/prog.Rd
+++ b/man/prog.Rd
@@ -29,13 +29,13 @@ b2 <- 2
 W1 <- runif(n, min = -2, max = 2)
 
 dat_treat <- glm_data(
-  b0+b1*abs(sin(W1))+b2*A,
+  Y ~ b0+b1*abs(sin(W1))+b2*A,
   W1 = W1,
   A = rbinom (n, 1, .5)
 )
 
 dat_notreat <- glm_data(
-  b0+b1*abs(sin(W1)),
+  Y ~ b0+b1*abs(sin(W1)),
   W1 = W1
 )
 

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -133,7 +133,7 @@ the \code{estimand_fun}.
 # Generate some data to showcase example
 n <- 100
 dat_gaus <- glm_data(
-  1+1.5*X1+2*A,
+  Y ~ 1+1.5*X1+2*A,
   X1 = rnorm(n),
   A = rbinom(n, 1, .5),
   family = gaussian()
@@ -150,7 +150,7 @@ estimand(ate)
 
 ## Another example with different family and specification of estimand_fun
 dat_binom <- glm_data(
-  1+1.5*X1+2*A,
+  Y ~ 1+1.5*X1+2*A,
   X1 = rnorm(n),
   A = rbinom(n, 1, .5),
   family = binomial()

--- a/man/rctglm_methods.Rd
+++ b/man/rctglm_methods.Rd
@@ -46,7 +46,7 @@ shortcuts to running \code{coef(x$glm)}.
 # Generate some data to showcase example
 n <- 100
 dat_binom <- glm_data(
-  1+1.5*X1+2*A,
+  Y ~ 1+1.5*X1+2*A,
   X1 = rnorm(n),
   A = rbinom(n, 1, .5),
   family = binomial()

--- a/man/rctglm_with_prognosticscore.Rd
+++ b/man/rctglm_with_prognosticscore.Rd
@@ -123,13 +123,13 @@ b2 <- 2
 W1 <- runif(n, min = -2, max = 2)
 
 dat_treat <- glm_data(
-  b0+b1*abs(sin(W1))+b2*A,
+  Y ~ b0+b1*abs(sin(W1))+b2*A,
   W1 = W1,
   A = rbinom (n, 1, .5)
 )
 
 dat_notreat <- glm_data(
-  b0+b1*abs(sin(W1)),
+  Y ~ b0+b1*abs(sin(W1)),
   W1 = W1
 )
 

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -14,6 +14,14 @@
         Estimate Std. Error
       1 1.762089  0.1885315
 
+---
+
+    Code
+      estimand(rr)
+    Output
+        Estimate Std. Error
+      1 40.80363   8.430044
+
 # `estimand_fun_derivX` can be left as NULL or specified manually
 
     Code

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -4,7 +4,7 @@
       estimand(ate_with_cv)
     Output
         Estimate Std. Error
-      1 1.762089  0.1932432
+      1 1.762089  0.1981473
 
 ---
 

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -56,10 +56,10 @@
           data = dat_treat_pois, group_indicator = A, estimand_fun = "rate_ratio", 
           data_hist = dat_notreat_pois, verbose = 0)
       
-      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.609
-      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 64.14
+      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 7.981
+      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 58.48
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.456)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.327 (0.5289)
 
 ---
 
@@ -73,8 +73,8 @@
           data = dat_treat_pois, group_indicator = A, estimand_fun = "rate_ratio", 
           data_hist = dat_notreat_pois, verbose = 0)
       
-      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.478
-      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 65.41
+      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.067
+      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 57.7
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.715 (0.4847)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.153 (0.5177)
 

--- a/tests/testthat/test-create_example_data.R
+++ b/tests/testthat/test-create_example_data.R
@@ -1,6 +1,6 @@
 test_that("`family_args` correctly passes arguments", {
   data <- glm_data(
-    1+2*x1,
+    Y ~ 1+2*x1,
     x1 = rep(1, 10),
     family_args = list(sd = 0)
   )
@@ -9,16 +9,30 @@ test_that("`family_args` correctly passes arguments", {
 
 test_that("Response is created as intended", {
   data <- glm_data(
-    1+2*x1,
+    Y ~ 1+2*x1,
     x1 = 1:2,
     family_args = list(sd = 0))
   expect_equal(data$Y, c(3, 5))
 })
 
+test_that("Coefficients can be defined variables outside the formula", {
+  withr::with_environment(rlang::new_environment(data = list(b0 = 1, b1 = 2)), {
+    data_extvars <- glm_data(
+      Y ~ b0+b1*x1,
+      x1 = 1:2,
+      family_args = list(sd = 0))
+  })
+  data_reg <- glm_data(
+    Y ~ 1+2*x1,
+    x1 = 1:2,
+    family_args = list(sd = 0))
+  expect_identical(data_extvars, data_reg)
+})
+
 test_that("Variables can be given as data.frame, list and individual variables", {
   ind_args <- withr::with_seed(42, {
     glm_data(
-      1+x1+2*x2,
+      Y ~ 1+x1+2*x2,
       x1 = 1:2,
       x2 = 4:5
     )
@@ -26,7 +40,7 @@ test_that("Variables can be given as data.frame, list and individual variables",
 
   list_args <- withr::with_seed(42, {
     glm_data(
-      1+x1+2*x2,
+      Y ~ 1+x1+2*x2,
       list(
         x1 = 1:2,
         x2 = 4:5
@@ -36,7 +50,7 @@ test_that("Variables can be given as data.frame, list and individual variables",
 
   df_args <- withr::with_seed(42, {
     glm_data(
-      1+x1+2*x2,
+      Y ~ 1+x1+2*x2,
       data.frame(
         x1 = 1:2,
         x2 = 4:5
@@ -51,19 +65,19 @@ test_that("Variables can be given as data.frame, list and individual variables",
 test_that("family can be given as character, function and call", {
   withr::local_seed(42)
   pois_data <- glm_data(
-    1+2*x1,
+    Y ~ 1+2*x1,
     x1 = 1:2,
     family = "poisson")
   expect_snapshot(pois_data)
 
   binom_data <- glm_data(
-    1+2*x1,
+    Y ~ 1+2*x1,
     x1 = 1:2,
     family = binomial)
   expect_snapshot(binom_data)
 
   nbinom_data <- glm_data(
-    1+2*x1,
+    Y ~ 1+2*x1,
     x1 = 1:2,
     family = MASS::negative.binomial(2))
   expect_snapshot(nbinom_data)
@@ -71,22 +85,21 @@ test_that("family can be given as character, function and call", {
 
 test_that("Changing `response_name` changes column name in resulting data", {
   data <- glm_data(
-    1+2*x1,
-    x1 = 1:2,
-    response_name = "test"
+    test ~ 1+2*x1,
+    x1 = 1:2
   )
   expect_true(!is.null(data$test))
 })
 
 test_that("Error occurs when no variables are given", {
   expect_error(
-    glm_data(1+x1)
+    glm_data(Y ~ 1+x1)
   )
 })
 
 test_that("Error occurs when trying to use variable in formula that's not defined", {
   expect_error(
-    glm_data(1+x1+x2, x1 = rnorm(10))
+    glm_data(Y ~ 1+x1+x2, x1 = rnorm(10))
   )
 })
 

--- a/tests/testthat/test-create_example_data.R
+++ b/tests/testthat/test-create_example_data.R
@@ -16,12 +16,12 @@ test_that("Response is created as intended", {
 })
 
 test_that("Coefficients can be defined variables outside the formula", {
-  withr::with_environment(rlang::new_environment(data = list(b0 = 1, b1 = 2)), {
-    data_extvars <- glm_data(
-      Y ~ b0+b1*x1,
-      x1 = 1:2,
-      family_args = list(sd = 0))
-  })
+  b0 <- 1
+  b1 <- 2
+  data_extvars <- glm_data(
+    Y ~ b0+b1*x1,
+    x1 = 1:2,
+    family_args = list(sd = 0))
   data_reg <- glm_data(
     Y ~ 1+2*x1,
     x1 = 1:2,
@@ -117,4 +117,12 @@ test_that("Error occurs in `check_family` when family is not valid", {
     },
     regexp = "'family' not recognized")
   })
+})
+
+test_that("Error occurs when response and `~` is missing", {
+  expect_error({
+    glm_data(1+2*x1,
+             x1 = rnorm(10))
+  },
+  regexp = "was not of class")
 })

--- a/tests/testthat/test-create_example_data.R
+++ b/tests/testthat/test-create_example_data.R
@@ -118,11 +118,3 @@ test_that("Error occurs in `check_family` when family is not valid", {
     regexp = "'family' not recognized")
   })
 })
-
-test_that("Error occurs when response and `~` is missing", {
-  expect_error({
-    glm_data(1+2*x1,
-             x1 = rnorm(10))
-  },
-  regexp = "was not of class")
-})

--- a/tests/testthat/test-fit_best_learner.R
+++ b/tests/testthat/test-fit_best_learner.R
@@ -66,9 +66,8 @@ test_that("`add_learners` returns data.frame with correct information", {
 # get_best_learner
 test_that("`get_best_learner` returns a workflow object", {
   dat <- glm_data(
-    1+2*x1,
-    x1 = rnorm(10),
-    response_name = "y"
+    y ~ 1+2*x1,
+    x1 = rnorm(10)
   )
   cv_folds <- rsample::vfold_cv(dat, v = 2)
   lrnr <- get_best_learner(resamples = cv_folds,
@@ -82,9 +81,8 @@ test_that("`get_best_learner` returns a workflow object", {
 #### Test commented out to avoid running tests for longer than necessary
 # test_that("`get_best_learner` can take in a character formula", {
 #   dat <- glm_data(
-#     1+2*x1,
-#     x1 = rnorm(10),
-#     response_name = "y"
+#     y ~ 1+2*x1,
+#     x1 = rnorm(10)
 #   )
 #   cv_folds <- rsample::vfold_cv(dat, v = 2)
 #   lrnr_chr <- get_best_learner(resamples = cv_folds,
@@ -104,9 +102,8 @@ cli::test_that_cli("`get_best_learner` print information when verbose > 0", {
   testthat::local_edition(3)
 
   dat <- glm_data(
-    1+2*x1,
-    x1 = rnorm(10),
-    response_name = "y"
+    y ~ 1+2*x1,
+    x1 = rnorm(10)
   )
   cv_folds <- rsample::vfold_cv(dat, v = 2)
   elapsed_time_pattern <- "\\d+\\.?\\d*m?s"
@@ -122,9 +119,8 @@ cli::test_that_cli("`get_best_learner` print information when verbose > 0", {
 # fit_best_learner
 test_that("`fit_best_learner` returns a workflow object", {
   dat <- glm_data(
-    1+2*x1,
-    x1 = rnorm(10),
-    response_name = "y"
+    y ~ 1+2*x1,
+    x1 = rnorm(10)
   )
 
   fit <- fit_best_learner(y ~ ., data = dat, verbose = 0)

--- a/tests/testthat/test-rctglm.R
+++ b/tests/testthat/test-rctglm.R
@@ -2,16 +2,25 @@ test_that("`rctglm` snapshot tests", {
   withr::local_seed(42)
   n <- 100
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
   )
+  dat_pois <- glm_data(
+    Y ~ 1+1.5*X1+2*A,
+    X1 = rnorm(n),
+    A = rbinom(n, 1, .5),
+    family = poisson()
+  )
 
-  ate_with_cv <- rctglm(formula = Y ~ .,
+  ate_with_cv <- withr::with_seed(42, {
+    rctglm(formula = Y ~ .,
                         group_indicator = A,
                         data = dat_gaus,
-                        family = gaussian)
+                        family = gaussian,
+                        cv_variance = TRUE)
+  })
   expect_s3_class(ate_with_cv, "rctglm")
   expect_snapshot(estimand(ate_with_cv))
 
@@ -21,13 +30,19 @@ test_that("`rctglm` snapshot tests", {
                       family = gaussian,
                       cv_variance = FALSE)
   expect_snapshot(estimand(ate_wo_cv))
+
+  rr <- rctglm(formula = Y ~ .,
+                        group_indicator = A,
+                        data = dat_pois,
+                        family = poisson())
+  expect_snapshot(estimand(rr))
 })
 
 test_that("`cv_variance` produces same point estimates but different SE estimates", {
   withr::local_seed(42)
   n <- 100
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
@@ -59,7 +74,7 @@ test_that("Different `cv_variance_folds` produces same estimate but different es
   withr::local_seed(42)
   n <- 100
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
@@ -92,7 +107,7 @@ test_that("Different `cv_variance_folds` produces same estimate but different es
 test_that("`rctglm` fails when `group_indicator` is non-binary", {
   n <- 100
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
@@ -113,7 +128,7 @@ test_that("`rctglm` fails when `group_indicator` is non-binary", {
 test_that("`estimand_fun` argument can be specified as function or character", {
   n <- 100
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
@@ -156,7 +171,7 @@ test_that("`estimand_fun_derivX` can be left as NULL or specified manually", {
   n <- 100
   withr::with_seed(42, {
     dat_gaus <- glm_data(
-      1+1.5*X1+2*A,
+      Y ~ 1+1.5*X1+2*A,
       X1 = rnorm(n),
       A = rbinom(n, 1, .5),
       family = gaussian()

--- a/tests/testthat/test-rctglm.R
+++ b/tests/testthat/test-rctglm.R
@@ -14,13 +14,11 @@ test_that("`rctglm` snapshot tests", {
     family = poisson()
   )
 
-  ate_with_cv <- withr::with_seed(42, {
-    rctglm(formula = Y ~ .,
+  ate_with_cv <- rctglm(formula = Y ~ .,
                         group_indicator = A,
                         data = dat_gaus,
                         family = gaussian,
                         cv_variance = TRUE)
-  })
   expect_s3_class(ate_with_cv, "rctglm")
   expect_snapshot(estimand(ate_with_cv))
 

--- a/tests/testthat/test-rctglm_methods.R
+++ b/tests/testthat/test-rctglm_methods.R
@@ -2,7 +2,7 @@ test_that("`estimand` method works", {
   withr::local_seed(42)
   n <- 10
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
@@ -32,7 +32,7 @@ test_that("`coef` method works", {
   withr::local_seed(42)
   n <- 10
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()
@@ -50,7 +50,7 @@ test_that("`coef` method works", {
 test_that("`print` method works", {
   n <- 10
   dat_gaus <- glm_data(
-    1+1.5*X1+2*A,
+    Y ~ 1+1.5*X1+2*A,
     X1 = rnorm(n),
     A = rbinom(n, 1, .5),
     family = gaussian()

--- a/tests/testthat/test-rctglm_prog_methods.R
+++ b/tests/testthat/test-rctglm_prog_methods.R
@@ -1,25 +1,21 @@
 test_that("`rctglm_with_prognosticscore` returns object of correct class", {
   withr::local_seed(42)
+  # Generate some data
+  n <- 100
+  b0 <- 1
+  b1 <- 1.5
+  b2 <- 2
+  W1 <- runif(n, min = -2, max = 2)
 
-    withr::with_environment(
-      rlang::new_environment(
-        data = list(b0 = 1,
-                    b1 = 1.5,
-                    b2 = 2,
-                    W1 = runif(100, min = -2, max = 2),
-                    A = rbinom (100, 1, .5))),
-      {
-        dat_treat <- glm_data(
-          Y ~ b0+b1*abs(sin(W1))+b2*A,
-          W1 = W1,
-          A = A
-        )
-        dat_notreat <- glm_data(
-          Y ~ b0+b1*abs(sin(W1)),
-          W1 = W1
-        )
-      }
-    )
+  dat_treat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1))+b2*A,
+    W1 = W1,
+    A = rbinom(n, 1, .5)
+  )
+  dat_notreat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1)),
+    W1 = W1
+  )
 
   ate <- rctglm_with_prognosticscore(
     formula = Y ~ .,

--- a/tests/testthat/test-rctglm_prog_methods.R
+++ b/tests/testthat/test-rctglm_prog_methods.R
@@ -1,21 +1,25 @@
 test_that("`rctglm_with_prognosticscore` returns object of correct class", {
   withr::local_seed(42)
-  # Generate some data
-  n <- 100
-  b0 <- 1
-  b1 <- 1.5
-  b2 <- 2
-  W1 <- runif(n, min = -2, max = 2)
 
-  dat_treat <- glm_data(
-    b0+b1*abs(sin(W1))+b2*A,
-    W1 = W1,
-    A = rbinom (n, 1, .5)
-  )
-  dat_notreat <- glm_data(
-    b0+b1*abs(sin(W1)),
-    W1 = W1
-  )
+    withr::with_environment(
+      rlang::new_environment(
+        data = list(b0 = 1,
+                    b1 = 1.5,
+                    b2 = 2,
+                    W1 = runif(100, min = -2, max = 2),
+                    A = rbinom (100, 1, .5))),
+      {
+        dat_treat <- glm_data(
+          Y ~ b0+b1*abs(sin(W1))+b2*A,
+          W1 = W1,
+          A = A
+        )
+        dat_notreat <- glm_data(
+          Y ~ b0+b1*abs(sin(W1)),
+          W1 = W1
+        )
+      }
+    )
 
   ate <- rctglm_with_prognosticscore(
     formula = Y ~ .,

--- a/tests/testthat/test-rctglm_with_prognosticscore.R
+++ b/tests/testthat/test-rctglm_with_prognosticscore.R
@@ -1,24 +1,20 @@
 test_that("`rctglm_with_prognosticscore` snapshot tests", {
   withr::local_seed(42)
 
-  withr::with_environment(
-    rlang::new_environment(
-      data = list(b0 = 1,
-                  b1 = 1.5,
-                  b2 = 2,
-                  W1 = runif(100, min = -2, max = 2),
-                  A = rbinom (100, 1, .5))),
-    {
-      dat_treat <- glm_data(
-        Y ~ b0+b1*abs(sin(W1))+b2*A,
-        W1 = W1,
-        A = A
-      )
-      dat_notreat <- glm_data(
-        Y ~ b0+b1*abs(sin(W1)),
-        W1 = W1
-      )
-    })
+  n <- 100
+  b0 <- 1
+  b1 <- 1.5
+  b2 <- 2
+  W1 <- runif(n, min = -2, max = 2)
+  dat_treat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1))+b2*A,
+    W1 = W1,
+    A = rbinom(n, 1, .5)
+  )
+  dat_notreat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1)),
+    W1 = W1
+  )
 
   elapsed_time_pattern <- "\\d+\\.?\\d*m?s"
   expect_snapshot({
@@ -53,26 +49,22 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
   },
   transform = function(x) gsub(elapsed_time_pattern, "", x))
 
-  withr::with_environment(
-    rlang::new_environment(
-      data = list(b0 = 1,
-                  b1 = 1.5,
-                  b2 = 2,
-                  W1 = runif(100, min = -2, max = 2),
-                  A = rbinom (100, 1, .5))),
-    {
-      dat_treat_pois <- glm_data(
-        Y ~ b0+b1*abs(sin(W1))+b2*A,
-        W1 = W1,
-        A = A,
-        family = poisson()
-      )
-      dat_notreat_pois <- glm_data(
-        Y ~ b0+b1*abs(sin(W1)),
-        W1 = W1,
-        family = poisson()
-      )
-    })
+  n <- 100
+  b0 <- 1
+  b1 <- 1.5
+  b2 <- 2
+  W1 <- runif(n, min = -2, max = 2)
+  dat_treat_pois <- glm_data(
+    Y ~ b0+b1*abs(sin(W1))+b2*A,
+    W1 = W1,
+    A = rbinom(n, 1, .5),
+    family = poisson()
+  )
+  dat_notreat_pois <- glm_data(
+    Y ~ b0+b1*abs(sin(W1)),
+    W1 = W1,
+    family = poisson()
+  )
 
   rr_pois <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
@@ -102,24 +94,20 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
 test_that("`cv_variance` produces same point estimates but different SE estimates", {
   withr::local_seed(42)
 
-  withr::with_environment(
-    rlang::new_environment(
-      data = list(b0 = 1,
-                  b1 = 1.5,
-                  b2 = 2,
-                  W1 = runif(100, min = -2, max = 2),
-                  A = rbinom (100, 1, .5))),
-    {
-      dat_treat <- glm_data(
-        Y ~ b0+b1*abs(sin(W1))+b2*A,
-        W1 = W1,
-        A = A
-      )
-      dat_notreat <- glm_data(
-        Y ~ b0+b1*abs(sin(W1)),
-        W1 = W1
-      )
-    })
+  n <- 100
+  b0 <- 1
+  b1 <- 1.5
+  b2 <- 2
+  W1 <- runif(n, min = -2, max = 2)
+  dat_treat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1))+b2*A,
+    W1 = W1,
+    A = rbinom(n, 1, .5)
+  )
+  dat_notreat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1)),
+    W1 = W1
+  )
 
   ate_w_cvvariance <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
@@ -159,24 +147,20 @@ test_that("`cv_variance` produces same point estimates but different SE estimate
 test_that("`prog_formula` manual specification consistent with default behavior", {
   withr::local_seed(42)
 
-  withr::with_environment(
-    rlang::new_environment(
-      data = list(b0 = 1,
-                  b1 = 1.5,
-                  b2 = 2,
-                  W1 = runif(100, min = -2, max = 2),
-                  A = rbinom (100, 1, .5))),
-    {
-      dat_treat <- glm_data(
-        Y ~ b0+b1*abs(sin(W1))+b2*A,
-        W1 = W1,
-        A = A
-      )
-      dat_notreat <- glm_data(
-        Y ~ b0+b1*abs(sin(W1)),
-        W1 = W1
-      )
-    })
+  n <- 100
+  b0 <- 1
+  b1 <- 1.5
+  b2 <- 2
+  W1 <- runif(n, min = -2, max = 2)
+  dat_treat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1))+b2*A,
+    W1 = W1,
+    A = rbinom(n, 1, .5)
+  )
+  dat_notreat <- glm_data(
+    Y ~ b0+b1*abs(sin(W1)),
+    W1 = W1
+  )
 
   # Note default behavior models response as all variables in data, in this case just W1
   ate_wo_prog_formula <- withr::with_seed(42, {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -72,6 +72,14 @@ test_that("`formula_everything` returns the correct formula object", {
     resp ~ .)
 })
 
+# check_formula
+test_that("`test_formula` works", {
+  expect_s3_class(check_formula("Y ~ 1 + X"), "formula")
+  expect_error(check_formula(2))
+  expect_error(check_formula(1+2*x1),
+               regexp = "was not of class")
+})
+
 # get01args
 test_that("`get01args` returns list of arguments with 0 and 1 in them", {
   ate <- function(psi0, psi1) psi1 - psi0
@@ -95,8 +103,8 @@ cli::test_that_cli("`get01args` gives error when arguments with 0 and 1 are miss
   argsnotendingwith0and1 <- function(psi0, psi18) psi18 - psi0
   expect_error({
     get01args(argsnotendingwith0and1)
-    },
-    regexp = "need to end in"
+  },
+  regexp = "need to end in"
   )
   missing1 <- function(a0, b) a0 - b
   expect_error({

--- a/vignettes/more-details.Rmd
+++ b/vignettes/more-details.Rmd
@@ -40,7 +40,7 @@ b2 <- 2
 
 # Simulate data with a non-linear effect
 dat_pois <- glm_data(
-  b0+b1*sin(W)^2+b2*A,
+  Y ~ b0+b1*sin(W)^2+b2*A,
   W = runif(n, min = -2, max = 2),
   A = rbinom(n, 1, .5),
   family = poisson(link = "log") # Default value
@@ -124,13 +124,13 @@ b2 <- 2
 W_sim <- runif(n, min = -2, max = 2)
 
 dat_treat <- glm_data(
-  b0+b1*abs(sin(W))+b2*A,
+  Y ~ b0+b1*abs(sin(W))+b2*A,
   W = W_sim,
   A = rbinom (n, 1, .5)
 )
 
 dat_notreat <- glm_data(
-  b0+b1*abs(sin(W)),
+  Y ~ b0+b1*abs(sin(W)),
   W = W_sim
 )
 ```


### PR DESCRIPTION
NOTE STATUS! Does not work right now. 

Issues:
- Defining values (like fx. `b0 <- 1`) and including it in the formula (like fx. `glm_data(Y~b0+...)`) works locally, but fails when running non-iteractively. 
  - README can be knitted locally with shift+ctrl+k, but `build_readme()` fails. Error is that it cannot find `b0` with the use case described above
  - Tests failed with same error as in the README, but using `withr::with_environment` seems to work
- There are issues with a few snapshot tests in `rctglm` and `rctglm_with_prognosticscore` where the SE estimate has changed. I do not know whether it's due to an issue with environments in the data simulation (see above), or if it's related to something else.

**EDIT NEW UPDATE:**
- Fixed issue with environment (first point above with `b0 <- 1`, etc.)
- Snapshots still different. Nothing has been changed in `rctglm` or `rctglm_with_prognosticscore` in these commits, so still unsure what is the cause. Maybe I thought it could be due to the data generating function being different now, and that could make the random number generation give different results though it's the same seed. But seems weird that only the SE estimation changes and not the estimate of the estimand.
  - See _snaps files for `rctglm` or `rctglm_with_prognosticscore`
  - NOTE however that running the code from the test locally with the same seed produces the "old" result. So seems to be a weird environment thing with testthat