### PR TITLE
rename/feat/fix: Renamed `group` args to `exposure`, fixed accidental rowname adjustment and full model counterfactual means

### DIFF
--- a/R/influence_function_utils.R
+++ b/R/influence_function_utils.R
@@ -55,10 +55,9 @@
 if_counterfactual_mean_glm <- function(response_variable,
                                        exposure_indicator,
                                        counterfactual_pred,
-                                       exposure_prob = 1/2
+                                       counterfactual_mean,
+                                       exposure_prob
 ) {
-  counterfactual_mean <- mean(counterfactual_pred)
-
   exposure_indicator/exposure_prob *
     (response_variable - counterfactual_pred) +
     (counterfactual_pred - counterfactual_mean)
@@ -85,9 +84,11 @@ if_counterfactual_mean_glm <- function(response_variable,
 #' @noRd
 if_marginaleffect <- function(response_variable,
                               exposure_indicator,
+                              exposure_prob,
                               counterfactual_pred0,
                               counterfactual_pred1,
-                              exposure_prob,
+                              counterfactual_mean0,
+                              counterfactual_mean1,
                               estimand_fun_deriv0,
                               estimand_fun_deriv1) {
 
@@ -95,17 +96,16 @@ if_marginaleffect <- function(response_variable,
     response_variable = response_variable,
     exposure_indicator = 1 - exposure_indicator,
     exposure_prob = 1 - exposure_prob,
-    counterfactual_pred = counterfactual_pred0
+    counterfactual_pred = counterfactual_pred0,
+    counterfactual_mean = counterfactual_mean0
   )
   counterfactual_mean_IF1 <- if_counterfactual_mean_glm(
     response_variable = response_variable,
     exposure_indicator = exposure_indicator,
     exposure_prob = exposure_prob,
-    counterfactual_pred = counterfactual_pred1
+    counterfactual_pred = counterfactual_pred1,
+    counterfactual_mean = counterfactual_mean1
   )
-
-  counterfactual_mean0 <- mean(counterfactual_pred0)
-  counterfactual_mean1 <- mean(counterfactual_pred1)
 
   if_estimand <- estimand_fun_deriv1(
     psi1 = counterfactual_mean1,

--- a/R/influence_function_utils.R
+++ b/R/influence_function_utils.R
@@ -5,7 +5,7 @@
 #' @param response_variable a `numeric vector` with the response variable in the model
 #' @param counterfactual_pred a `numeric vector` with predictions of the response variable for all
 #' observations a hypothetic scenario of all observations being in the same group defined by
-#' `group_indicator`. See more in details.
+#' `exposure_indicator`. See more in details.
 #'
 #' @details
 #' Assuming we have a response variable \eqn{Y}, design matrix \eqn{X} and link function \eqn{g}, a GLM
@@ -48,18 +48,18 @@
 #' pred0 <- predict(mod, type = "response", newdata = dat0)
 #' if_countmean0 <- if_counterfactual_mean_glm(
 #'   response_variable = dat0$Y,
-#'   group_indicator = dat0$A,
+#'   exposure_indicator = dat0$A,
 #'   counterfactual_pred = pred0)
 #'
 #' @noRd
 if_counterfactual_mean_glm <- function(response_variable,
-                                       group_indicator,
+                                       exposure_indicator,
                                        counterfactual_pred,
-                                       group_allocation_prob = 1/2
+                                       exposure_prob = 1/2
 ) {
   counterfactual_mean <- mean(counterfactual_pred)
 
-  group_indicator/group_allocation_prob *
+  exposure_indicator/exposure_prob *
     (response_variable - counterfactual_pred) +
     (counterfactual_pred - counterfactual_mean)
 }
@@ -84,23 +84,23 @@ if_counterfactual_mean_glm <- function(response_variable,
 #'
 #' @noRd
 if_marginaleffect <- function(response_variable,
-                              group_indicator,
+                              exposure_indicator,
                               counterfactual_pred0,
                               counterfactual_pred1,
-                              group_allocation_prob,
+                              exposure_prob,
                               estimand_fun_deriv0,
                               estimand_fun_deriv1) {
 
   counterfactual_mean_IF0 <- if_counterfactual_mean_glm(
     response_variable = response_variable,
-    group_indicator = 1 - group_indicator,
-    group_allocation_prob = 1 - group_allocation_prob,
+    exposure_indicator = 1 - exposure_indicator,
+    exposure_prob = 1 - exposure_prob,
     counterfactual_pred = counterfactual_pred0
   )
   counterfactual_mean_IF1 <- if_counterfactual_mean_glm(
     response_variable = response_variable,
-    group_indicator = group_indicator,
-    group_allocation_prob = group_allocation_prob,
+    exposure_indicator = exposure_indicator,
+    exposure_prob = exposure_prob,
     counterfactual_pred = counterfactual_pred1
   )
 

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -161,7 +161,10 @@ rctglm <- function(formula,
   group_vals_unique <- unique(group_vals)
   if (!all(c(0,1) %in% group_vals)) cli::cli_abort("{.var exposure_indicator} column can only have 1's and 0's")
 
-  checkmate::assert_numeric(exposure_prob)
+  exposure_prob_is_num <- inherits(exposure_prob, "numeric")
+  exposure_in_range <- exposure_prob > 0 & exposure_prob < 1
+  if (!exposure_prob_is_num | !exposure_in_range)
+    cli::cli_abort("`exposure_prob` needs to be a probability, i.e. a numeric between 0 and 1")
   # if (is.null(exposure_prob)) {
   #   exposure_prob <- mean(group_vals)
   #   if (verbose >= 1)

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -86,16 +86,19 @@
 #' @examples
 #' # Generate some data to showcase example
 #' n <- 100
+#' exposure_prob <- .5
+#'
 #' dat_gaus <- glm_data(
 #'   1+1.5*X1+2*A,
 #'   X1 = rnorm(n),
-#'   A = rbinom(n, 1, .5),
+#'   A = rbinom(n, 1, exposure_prob),
 #'   family = gaussian()
 #' )
 #'
 #' # Fit the model
 #' ate <- rctglm(formula = Y ~ .,
 #'               exposure_indicator = A,
+#'               exposure_prob = exposure_prob,
 #'               data = dat_gaus,
 #'               family = gaussian)
 #'
@@ -106,12 +109,13 @@
 #' dat_binom <- glm_data(
 #'   1+1.5*X1+2*A,
 #'   X1 = rnorm(n),
-#'   A = rbinom(n, 1, .5),
+#'   A = rbinom(n, 1, exposure_prob),
 #'   family = binomial()
 #' )
 #'
 #' rr <- rctglm(formula = Y ~ .,
 #'               exposure_indicator = A,
+#'               exposure_prob = exposure_prob,
 #'               data = dat_binom,
 #'               family = binomial(),
 #'               estimand_fun = "rate_ratio")
@@ -119,6 +123,7 @@
 #' odds_ratio <- function(psi1, psi0) (psi1*(1-psi0))/(psi0*(1-psi1))
 #' or <- rctglm(formula = Y ~ .,
 #'               exposure_indicator = A,
+#'               exposure_prob = exposure_prob,
 #'               data = dat_binom,
 #'               family = binomial,
 #'               estimand_fun = odds_ratio)
@@ -132,7 +137,7 @@ rctglm <- function(formula,
                    estimand_fun = "ate",
                    estimand_fun_deriv0 = NULL, estimand_fun_deriv1 = NULL,
                    cv_variance = TRUE,
-                   cv_variance_folds = 5,
+                   cv_variance_folds = 10,
                    verbose = options::opt("verbose"),
                    ...
 ) {

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -17,7 +17,7 @@
 #' @param exposure_prob a `numeric` with the probabiliy of being in
 #' "group 1" (rather than group 0) in groups defined by `exposure_indicator`.
 #' As a default, the ratio of 1's in data is used.
-#' @param estimand_fun a `function` with arguments `psi0` and `psi1` specifying
+#' @param estimand_fun a `function` with arguments `psi1` and `psi0` specifying
 #' the estimand. Alternative, specify "ate" or "rate_ratio" as a `character`
 #' to use one of the default estimand functions. See
 #' more details in the "Estimand" section of this documentation.
@@ -197,10 +197,12 @@ rctglm <- function(formula,
     exposure_indicator_name = exposure_indicator_name
   )
   full_model_means_counterfactual <- colMeans(full_model_fitted.values_counterfactual)
+  full_model_means_counterfactual0 <- as.numeric(full_model_means_counterfactual["psi0"])
+  full_model_means_counterfactual1 <- as.numeric(full_model_means_counterfactual["psi1"])
 
   estimate_estimand <- estimand_fun(
-    as.numeric(full_model_means_counterfactual["psi1"]),
-    as.numeric(full_model_means_counterfactual["psi0"])
+    psi1 = full_model_means_counterfactual1,
+    psi0 = full_model_means_counterfactual0
   )
 
   # If cv_variance then use out-of-sample counterfactual predictions, otherwise
@@ -222,6 +224,8 @@ rctglm <- function(formula,
     exposure_prob = exposure_prob,
     counterfactual_pred0 = preds_for_variance$psi0,
     counterfactual_pred1 = preds_for_variance$psi1,
+    counterfactual_mean0 = full_model_means_counterfactual0,
+    counterfactual_mean1 = full_model_means_counterfactual1,
     estimand_fun_deriv0 = estimand_fun_deriv0,
     estimand_fun_deriv1 = estimand_fun_deriv1)
 

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -11,10 +11,11 @@
 #' @param formula an object of class "formula" (or one that can be coerced to that class):
 #' a symbolic description of the model to be fitted. The details of model specification are
 #' given under ‘Details’ in the [glm] documentation.
-#' @param group_indicator (name of) the *binary* variable in `data` that
+#' @param exposure_indicator (name of) the *binary* variable in `data` that
 #' identifies randomisation groups. The variable is required to be binary to
 #' make the "orientation" of the `estimand_fun` clear.
-#' @param group_allocation_prob a `numeric` with the probabiliy of being assigned "group 1" (rather than group 0).
+#' @param exposure_prob a `numeric` with the probabiliy of being in
+#' "group 1" (rather than group 0) in groups defined by `exposure_indicator`.
 #' As a default, the ratio of 1's in data is used.
 #' @param estimand_fun a `function` with arguments `psi0` and `psi1` specifying
 #' the estimand. Alternative, specify "ate" or "rate_ratio" as a `character`
@@ -32,8 +33,8 @@
 #'
 #' @details
 #' The procedure assumes the setup of a randomised clinical trial with observations grouped by a binary
-#' `group_indicator` variable, allocated randomly with probability `group_allocation_prob`. A GLM is
-#' fit and then used to predict the response of all observations in the event that the `group_indicator`
+#' `exposure_indicator` variable, allocated randomly with probability `exposure_prob`. A GLM is
+#' fit and then used to predict the response of all observations in the event that the `exposure_indicator`
 #' is 0 and 1, respectively. Taking means of these predictions produce the *counterfactual means*
 #' `psi0` and `psi1`, and an estimand `r(psi0, psi1)` is calculated using any specified `estimand_fun`.
 #'
@@ -41,14 +42,14 @@
 #' If `cv_variance` is `TRUE`, then the counterfactual predictions for each observation (which are
 #' used to calculate the value of the influence function) is obtained as out-of-sample (OOS) predictions
 #' using cross validation with number of folds specified by `cv_variance_folds`. The cross validation splits
-#' are performed using stratified sampling with `group_indicator` as the `strata` argument in [rsample::vfold_cv].
+#' are performed using stratified sampling with `exposure_indicator` as the `strata` argument in [rsample::vfold_cv].
 #'
 #' This method of inference using plug-in estimation and influence functions for the variance produces a
 #' causal estimate of the estimand, as stated by articles XXXX.
 #'
 #' @section Estimands:
 #' As noted in the description, `psi0` and `psi1` are the counterfactual means found by prediction using
-#' a fitted GLM in the binary groups defined by `group_indicator`.
+#' a fitted GLM in the binary groups defined by `exposure_indicator`.
 #'
 #' Default estimand functions can be specified via `"ate"` (which uses the function
 #' `function(psi1, psi0) psi1-psi0`) and `"rate_ratio"` (which uses the function
@@ -94,7 +95,7 @@
 #'
 #' # Fit the model
 #' ate <- rctglm(formula = Y ~ .,
-#'               group_indicator = A,
+#'               exposure_indicator = A,
 #'               data = dat_gaus,
 #'               family = gaussian)
 #'
@@ -110,24 +111,24 @@
 #' )
 #'
 #' rr <- rctglm(formula = Y ~ .,
-#'               group_indicator = A,
+#'               exposure_indicator = A,
 #'               data = dat_binom,
 #'               family = binomial(),
 #'               estimand_fun = "rate_ratio")
 #'
 #' odds_ratio <- function(psi1, psi0) (psi1*(1-psi0))/(psi0*(1-psi1))
 #' or <- rctglm(formula = Y ~ .,
-#'               group_indicator = A,
+#'               exposure_indicator = A,
 #'               data = dat_binom,
 #'               family = binomial,
 #'               estimand_fun = odds_ratio)
 #'
 #'
 rctglm <- function(formula,
-                   group_indicator,
+                   exposure_indicator,
+                   exposure_prob,
                    family,
                    data,
-                   group_allocation_prob = NULL,
                    estimand_fun = "ate",
                    estimand_fun_deriv0 = NULL, estimand_fun_deriv1 = NULL,
                    cv_variance = TRUE,
@@ -136,30 +137,31 @@ rctglm <- function(formula,
                    ...
 ) {
 
-  # TODO: Right now, estimand_fun needs to have arguments with 0 and 1 in them, and the group_indicator
+  # TODO: Right now, estimand_fun needs to have arguments with 0 and 1 in them, and the exposure_indicator
   # needs to take values 0 and 1. Generalise this to work for factors and be able to set reference level
 
-  group_indicator <- rlang::enquo(group_indicator)
+  exposure_indicator <- rlang::enquo(exposure_indicator)
   args <- as.list(environment())
   cal <- match.call()
 
-  ind_expr <- rlang::quo_get_expr(group_indicator)
-  called_within_prognosticscore <- ind_expr == "group_indicator"
+  ind_expr <- rlang::quo_get_expr(exposure_indicator)
+  called_within_prognosticscore <- ind_expr == "exposure_indicator"
   if (called_within_prognosticscore) {
-    group_indicator_name <- as.character(rlang::quo_get_expr(rlang::eval_tidy(group_indicator)))
+    exposure_indicator_name <- as.character(rlang::quo_get_expr(rlang::eval_tidy(exposure_indicator)))
   } else {
-    group_indicator_name <- as.character(ind_expr)
+    exposure_indicator_name <- as.character(ind_expr)
   }
 
-  group_vals <- dplyr::pull(data, tidyselect::all_of(group_indicator_name))
+  group_vals <- dplyr::pull(data, tidyselect::all_of(exposure_indicator_name))
   group_vals_unique <- unique(group_vals)
-  if (!all(c(0,1) %in% group_vals)) cli::cli_abort("{.var group_indicator} column can only have 1's and 0's")
+  if (!all(c(0,1) %in% group_vals)) cli::cli_abort("{.var exposure_indicator} column can only have 1's and 0's")
 
-  if (is.null(group_allocation_prob)) {
-    group_allocation_prob <- mean(group_vals)
-    if (verbose >= 1)
-      cli::cli_alert_info("Setting the group allocation probability {.var group_allocation_prob} as the mean of column {.var {group_indicator_name}} in data: {group_allocation_prob}")
-  }
+  checkmate::assert_numeric(exposure_prob)
+  # if (is.null(exposure_prob)) {
+  #   exposure_prob <- mean(group_vals)
+  #   if (verbose >= 1)
+  #     cli::cli_alert_info("Setting the group allocation probability {.var exposure_prob} as the mean of column {.var {exposure_indicator_name}} in data: {exposure_prob}")
+  # }
 
   if (is.character(estimand_fun)) estimand_fun <- default_estimand_funs(estimand_fun)
 
@@ -187,12 +189,12 @@ rctglm <- function(formula,
   model <- do.call(glm, args = args_glm)
 
   response_var <- model$y
-  group_indicator_var <- data %>%
-    dplyr::pull(tidyselect::all_of(group_indicator_name))
+  exposure_indicator_var <- data %>%
+    dplyr::pull(tidyselect::all_of(exposure_indicator_name))
 
   full_model_fitted.values_counterfactual <- predict_counterfactual_means(
     model = model,
-    group_indicator_name = group_indicator_name
+    exposure_indicator_name = exposure_indicator_name
   )
   full_model_means_counterfactual <- colMeans(full_model_fitted.values_counterfactual)
 
@@ -206,7 +208,7 @@ rctglm <- function(formula,
   preds_for_variance <- if (cv_variance) {
     oos_fitted.values_counterfactual(
       data = data,
-      group_indicator_name = group_indicator_name,
+      exposure_indicator_name = exposure_indicator_name,
       full_model.args_glm = args_glm,
       cv_variance_folds = cv_variance_folds
     )
@@ -216,8 +218,8 @@ rctglm <- function(formula,
 
   if_marginaleffect_val <- if_marginaleffect(
     response_variable = response_var,
-    group_indicator = group_indicator_var,
-    group_allocation_prob = group_allocation_prob,
+    exposure_indicator = exposure_indicator_var,
+    exposure_prob = exposure_prob,
     counterfactual_pred0 = preds_for_variance$psi0,
     counterfactual_pred1 = preds_for_variance$psi1,
     estimand_fun_deriv0 = estimand_fun_deriv0,

--- a/R/rctglm_methods.R
+++ b/R/rctglm_methods.R
@@ -25,16 +25,18 @@
 #' @examples
 #' # Generate some data to showcase example
 #' n <- 100
+#' exposure_prob <- .5
 #' dat_binom <- glm_data(
 #'   1+1.5*X1+2*A,
 #'   X1 = rnorm(n),
-#'   A = rbinom(n, 1, .5),
+#'   A = rbinom(n, 1, exposure_prob),
 #'   family = binomial()
 #' )
 #'
 #' # Fit the model
 #' ate <- rctglm(formula = Y ~ .,
 #'               exposure_indicator = A,
+#'               exposure_prob = exposure_prob,
 #'               data = dat_binom,
 #'               family = binomial,
 #'               estimand_fun = "ate")

--- a/R/rctglm_methods.R
+++ b/R/rctglm_methods.R
@@ -34,7 +34,7 @@
 #'
 #' # Fit the model
 #' ate <- rctglm(formula = Y ~ .,
-#'               group_indicator = A,
+#'               exposure_indicator = A,
 #'               data = dat_binom,
 #'               family = binomial,
 #'               estimand_fun = "ate")

--- a/R/rctglm_prog_methods.R
+++ b/R/rctglm_prog_methods.R
@@ -30,7 +30,7 @@
 #'
 #' ate <- rctglm_with_prognosticscore(
 #'   formula = Y ~ .,
-#'   group_indicator = A,
+#'   exposure_indicator = A,
 #'   data = dat_treat,
 #'   family = gaussian(),
 #'   estimand_fun = "ate",

--- a/R/rctglm_prog_methods.R
+++ b/R/rctglm_prog_methods.R
@@ -16,11 +16,12 @@
 #' b1 <- 1.5
 #' b2 <- 2
 #' W1 <- runif(n, min = -2, max = 2)
+#' exposure_prob <- .5
 #'
 #' dat_treat <- glm_data(
 #'   b0+b1*abs(sin(W1))+b2*A,
 #'   W1 = W1,
-#'   A = rbinom (n, 1, .5)
+#'   A = rbinom(n, 1, exposure_prob)
 #' )
 #'
 #' dat_notreat <- glm_data(
@@ -31,6 +32,7 @@
 #' ate <- rctglm_with_prognosticscore(
 #'   formula = Y ~ .,
 #'   exposure_indicator = A,
+#'   exposure_prob = exposure_prob,
 #'   data = dat_treat,
 #'   family = gaussian(),
 #'   estimand_fun = "ate",

--- a/R/rctglm_with_prognosticscore.R
+++ b/R/rctglm_with_prognosticscore.R
@@ -58,7 +58,7 @@
 #'
 #' ate <- rctglm_with_prognosticscore(
 #'   formula = Y ~ .,
-#'   group_indicator = A,
+#'   exposure_indicator = A,
 #'   data = dat_treat,
 #'   family = gaussian(),
 #'   estimand_fun = "ate",
@@ -70,8 +70,8 @@ rctglm_with_prognosticscore <- function(
     formula,
     family,
     data,
-    group_indicator,
-    group_allocation_prob = NULL,
+    exposure_indicator,
+    exposure_prob = NULL,
     estimand_fun = "ate",
     estimand_fun_deriv0 = NULL, estimand_fun_deriv1 = NULL,
     cv_variance = TRUE,
@@ -85,7 +85,7 @@ rctglm_with_prognosticscore <- function(
 
   call <- match.call()
 
-  group_indicator <- rlang::enquo(group_indicator)
+  exposure_indicator <- rlang::enquo(exposure_indicator)
   named_args <- as.list(environment())
   extra_glm_args <- list(...)
 
@@ -132,8 +132,8 @@ rctglm_with_prognosticscore <- function(
     formula = formula_with_prognosticscore,
     family = family,
     data = data,
-    group_indicator = group_indicator,
-    group_allocation_prob = group_allocation_prob,
+    exposure_indicator = exposure_indicator,
+    exposure_prob = exposure_prob,
     estimand_fun = estimand_fun,
     estimand_fun_deriv0 = estimand_fun_deriv0,
     estimand_fun_deriv1 = estimand_fun_deriv1,

--- a/R/rctglm_with_prognosticscore.R
+++ b/R/rctglm_with_prognosticscore.R
@@ -44,11 +44,12 @@
 #' b1 <- 1.5
 #' b2 <- 2
 #' W1 <- runif(n, min = -2, max = 2)
+#' exposure_prob <- .5
 #'
 #' dat_treat <- glm_data(
 #'   b0+b1*abs(sin(W1))+b2*A,
 #'   W1 = W1,
-#'   A = rbinom (n, 1, .5)
+#'   A = rbinom (n, 1, exposure_prob)
 #' )
 #'
 #' dat_notreat <- glm_data(
@@ -59,6 +60,7 @@
 #' ate <- rctglm_with_prognosticscore(
 #'   formula = Y ~ .,
 #'   exposure_indicator = A,
+#'   exposure_prob = exposure_prob,
 #'   data = dat_treat,
 #'   family = gaussian(),
 #'   estimand_fun = "ate",
@@ -75,7 +77,7 @@ rctglm_with_prognosticscore <- function(
     estimand_fun = "ate",
     estimand_fun_deriv0 = NULL, estimand_fun_deriv1 = NULL,
     cv_variance = TRUE,
-    cv_variance_folds = 5,
+    cv_variance_folds = 10,
     ...,
     data_hist,
     prog_formula = NULL,

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,7 +51,7 @@ b2 <- 2
 dat_treat <- glm_data(
   b0+b1*sin(W)^2+b2*A,
   W = runif(n, min = -2, max = 2),
-  A = rbinom(n, 1, .5),
+  A = rbinom(n, 1, prob = 1/2),
   family = gaussian() # Default value
 )
 ```
@@ -77,6 +77,7 @@ Thus, we can estimate the ATE by simply writing the below:
 ```{r noprog-run}
 ate <- rctglm(formula = Y ~ A * W,
               exposure_indicator = A,
+              exposure_prob = 1/2,
               data = dat_treat,
               family = "gaussian") # Default value
 ```
@@ -140,6 +141,7 @@ Thus, a simple call which estimates the average treatment effect, adjusting for 
 ate_prog <- rctglm_with_prognosticscore(
   formula = Y ~ A * W,
   exposure_indicator = A,
+  exposure_prob = 1/2,
   data = dat_treat,
   family = gaussian(link = "identity"), # Default value
   data_hist = dat_notreat)

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,7 +76,7 @@ Thus, we can estimate the ATE by simply writing the below:
 
 ```{r noprog-run}
 ate <- rctglm(formula = Y ~ A * W,
-              group_indicator = A,
+              exposure_indicator = A,
               data = dat_treat,
               family = "gaussian") # Default value
 ```
@@ -139,7 +139,7 @@ Thus, a simple call which estimates the average treatment effect, adjusting for 
 ```{r prog-run}
 ate_prog <- rctglm_with_prognosticscore(
   formula = Y ~ A * W,
-  group_indicator = A,
+  exposure_indicator = A,
   data = dat_treat,
   family = gaussian(link = "identity"), # Default value
   data_hist = dat_notreat)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ b2 <- 2
 dat_treat <- glm_data(
   b0+b1*sin(W)^2+b2*A,
   W = runif(n, min = -2, max = 2),
-  A = rbinom(n, 1, .5),
+  A = rbinom(n, 1, prob = 1/2),
   family = gaussian() # Default value
 )
 ```
@@ -86,7 +86,8 @@ Thus, we can estimate the ATE by simply writing the below:
 
 ``` r
 ate <- rctglm(formula = Y ~ A * W,
-              group_indicator = A,
+              exposure_indicator = A,
+              exposure_prob = 1/2,
               data = dat_treat,
               family = "gaussian") # Default value
 ```
@@ -98,13 +99,13 @@ ate
 #> 
 #> Object of class rctglm 
 #> 
-#> Call:  rctglm(formula = Y ~ A * W, group_indicator = A, family = "gaussian", 
-#>     data = dat_treat)
+#> Call:  rctglm(formula = Y ~ A * W, exposure_indicator = A, exposure_prob = 1/2, 
+#>     family = "gaussian", data = dat_treat)
 #> 
 #> Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.776
 #> Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 4.867
 #> Estimand function r: psi1 - psi0
-#> Estimand (r(psi_1, psi_0)) estimate (SE): 2.091 (0.09225)
+#> Estimand (r(psi_1, psi_0)) estimate (SE): 2.091 (0.09229)
 ```
 
 ### Structure of `rctglm` and methods for extracting entities
@@ -133,7 +134,7 @@ Thus, methods available are:
 # "estimate" also available as alternative to just "est"
 est(ate)
 #>   Estimate Std. Error
-#> 1 2.091095 0.09224543
+#> 1 2.091095 0.09229488
 coef(ate)
 #> (Intercept)           A           W         A:W 
 #>  2.77585401  2.09122279  0.02364106  0.04961895
@@ -182,7 +183,8 @@ adjusting for a prognostic score, is seen below:
 ``` r
 ate_prog <- rctglm_with_prognosticscore(
   formula = Y ~ A * W,
-  group_indicator = A,
+  exposure_indicator = A,
+  exposure_prob = 1/2,
   data = dat_treat,
   family = gaussian(link = "identity"), # Default value
   data_hist = dat_notreat)
@@ -196,12 +198,13 @@ ate_prog
 #> Object of class rctglm_prog 
 #> 
 #> Call:  rctglm_with_prognosticscore(formula = Y ~ A * W, family = gaussian(link = "identity"), 
-#>     data = dat_treat, group_indicator = A, data_hist = dat_notreat)
+#>     data = dat_treat, exposure_indicator = A, exposure_prob = 1/2, 
+#>     data_hist = dat_notreat)
 #> 
-#> Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.828
-#> Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 4.819
+#> Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 2.824
+#> Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 4.822
 #> Estimand function r: psi1 - psi0
-#> Estimand (r(psi_1, psi_0)) estimate (SE): 1.992 (0.06445)
+#> Estimand (r(psi_1, psi_0)) estimate (SE): 1.999 (0.06393)
 ```
 
 It’s evident that in this case where there is a non-linear relationship

--- a/man/prog.Rd
+++ b/man/prog.Rd
@@ -41,7 +41,7 @@ dat_notreat <- glm_data(
 
 ate <- rctglm_with_prognosticscore(
   formula = Y ~ .,
-  group_indicator = A,
+  exposure_indicator = A,
   data = dat_treat,
   family = gaussian(),
   estimand_fun = "ate",

--- a/man/prog.Rd
+++ b/man/prog.Rd
@@ -27,11 +27,12 @@ b0 <- 1
 b1 <- 1.5
 b2 <- 2
 W1 <- runif(n, min = -2, max = 2)
+exposure_prob <- .5
 
 dat_treat <- glm_data(
   b0+b1*abs(sin(W1))+b2*A,
   W1 = W1,
-  A = rbinom (n, 1, .5)
+  A = rbinom(n, 1, exposure_prob)
 )
 
 dat_notreat <- glm_data(
@@ -42,6 +43,7 @@ dat_notreat <- glm_data(
 ate <- rctglm_with_prognosticscore(
   formula = Y ~ .,
   exposure_indicator = A,
+  exposure_prob = exposure_prob,
   data = dat_treat,
   family = gaussian(),
   estimand_fun = "ate",

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -15,7 +15,7 @@ rctglm(
   estimand_fun_deriv0 = NULL,
   estimand_fun_deriv1 = NULL,
   cv_variance = TRUE,
-  cv_variance_folds = 5,
+  cv_variance_folds = 10,
   verbose = options::opt("verbose"),
   ...
 )
@@ -46,7 +46,7 @@ As a default, the ratio of 1's in data is used.}
     variables are taken from \code{environment(formula)},
     typically the environment from which \code{glm} is called.}
 
-\item{estimand_fun}{a \code{function} with arguments \code{psi0} and \code{psi1} specifying
+\item{estimand_fun}{a \code{function} with arguments \code{psi1} and \code{psi0} specifying
 the estimand. Alternative, specify "ate" or "rate_ratio" as a \code{character}
 to use one of the default estimand functions. See
 more details in the "Estimand" section of this documentation.}
@@ -133,16 +133,19 @@ the \code{estimand_fun}.
 \examples{
 # Generate some data to showcase example
 n <- 100
+exposure_prob <- .5
+
 dat_gaus <- glm_data(
   1+1.5*X1+2*A,
   X1 = rnorm(n),
-  A = rbinom(n, 1, .5),
+  A = rbinom(n, 1, exposure_prob),
   family = gaussian()
 )
 
 # Fit the model
 ate <- rctglm(formula = Y ~ .,
               exposure_indicator = A,
+              exposure_prob = exposure_prob,
               data = dat_gaus,
               family = gaussian)
 
@@ -153,12 +156,13 @@ estimand(ate)
 dat_binom <- glm_data(
   1+1.5*X1+2*A,
   X1 = rnorm(n),
-  A = rbinom(n, 1, .5),
+  A = rbinom(n, 1, exposure_prob),
   family = binomial()
 )
 
 rr <- rctglm(formula = Y ~ .,
               exposure_indicator = A,
+              exposure_prob = exposure_prob,
               data = dat_binom,
               family = binomial(),
               estimand_fun = "rate_ratio")
@@ -166,6 +170,7 @@ rr <- rctglm(formula = Y ~ .,
 odds_ratio <- function(psi1, psi0) (psi1*(1-psi0))/(psi0*(1-psi1))
 or <- rctglm(formula = Y ~ .,
               exposure_indicator = A,
+              exposure_prob = exposure_prob,
               data = dat_binom,
               family = binomial,
               estimand_fun = odds_ratio)

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -7,10 +7,10 @@ influence functions}
 \usage{
 rctglm(
   formula,
-  group_indicator,
+  exposure_indicator,
+  exposure_prob,
   family,
   data,
-  group_allocation_prob = NULL,
   estimand_fun = "ate",
   estimand_fun_deriv0 = NULL,
   estimand_fun_deriv1 = NULL,
@@ -25,9 +25,13 @@ rctglm(
 a symbolic description of the model to be fitted. The details of model specification are
 given under ‘Details’ in the \link{glm} documentation.}
 
-\item{group_indicator}{(name of) the \emph{binary} variable in \code{data} that
+\item{exposure_indicator}{(name of) the \emph{binary} variable in \code{data} that
 identifies randomisation groups. The variable is required to be binary to
 make the "orientation" of the \code{estimand_fun} clear.}
+
+\item{exposure_prob}{a \code{numeric} with the probabiliy of being in
+"group 1" (rather than group 0) in groups defined by \code{exposure_indicator}.
+As a default, the ratio of 1's in data is used.}
 
 \item{family}{a description of the error distribution and link
     function to be used in the model.  For \code{glm} this can be a
@@ -41,9 +45,6 @@ make the "orientation" of the \code{estimand_fun} clear.}
     the variables in the model.  If not found in \code{data}, the
     variables are taken from \code{environment(formula)},
     typically the environment from which \code{glm} is called.}
-
-\item{group_allocation_prob}{a \code{numeric} with the probabiliy of being assigned "group 1" (rather than group 0).
-As a default, the ratio of 1's in data is used.}
 
 \item{estimand_fun}{a \code{function} with arguments \code{psi0} and \code{psi1} specifying
 the estimand. Alternative, specify "ate" or "rate_ratio" as a \code{character}
@@ -99,8 +100,8 @@ covariates in randomisation groups.
 }
 \details{
 The procedure assumes the setup of a randomised clinical trial with observations grouped by a binary
-\code{group_indicator} variable, allocated randomly with probability \code{group_allocation_prob}. A GLM is
-fit and then used to predict the response of all observations in the event that the \code{group_indicator}
+\code{exposure_indicator} variable, allocated randomly with probability \code{exposure_prob}. A GLM is
+fit and then used to predict the response of all observations in the event that the \code{exposure_indicator}
 is 0 and 1, respectively. Taking means of these predictions produce the \emph{counterfactual means}
 \code{psi0} and \code{psi1}, and an estimand \code{r(psi0, psi1)} is calculated using any specified \code{estimand_fun}.
 
@@ -108,7 +109,7 @@ The variance of the estimand is found by taking the variance of the influence fu
 If \code{cv_variance} is \code{TRUE}, then the counterfactual predictions for each observation (which are
 used to calculate the value of the influence function) is obtained as out-of-sample (OOS) predictions
 using cross validation with number of folds specified by \code{cv_variance_folds}. The cross validation splits
-are performed using stratified sampling with \code{group_indicator} as the \code{strata} argument in \link[rsample:vfold_cv]{rsample::vfold_cv}.
+are performed using stratified sampling with \code{exposure_indicator} as the \code{strata} argument in \link[rsample:vfold_cv]{rsample::vfold_cv}.
 
 This method of inference using plug-in estimation and influence functions for the variance produces a
 causal estimate of the estimand, as stated by articles XXXX.
@@ -116,7 +117,7 @@ causal estimate of the estimand, as stated by articles XXXX.
 \section{Estimands}{
 
 As noted in the description, \code{psi0} and \code{psi1} are the counterfactual means found by prediction using
-a fitted GLM in the binary groups defined by \code{group_indicator}.
+a fitted GLM in the binary groups defined by \code{exposure_indicator}.
 
 Default estimand functions can be specified via \code{"ate"} (which uses the function
 \code{function(psi1, psi0) psi1-psi0}) and \code{"rate_ratio"} (which uses the function
@@ -141,7 +142,7 @@ dat_gaus <- glm_data(
 
 # Fit the model
 ate <- rctglm(formula = Y ~ .,
-              group_indicator = A,
+              exposure_indicator = A,
               data = dat_gaus,
               family = gaussian)
 
@@ -157,14 +158,14 @@ dat_binom <- glm_data(
 )
 
 rr <- rctglm(formula = Y ~ .,
-              group_indicator = A,
+              exposure_indicator = A,
               data = dat_binom,
               family = binomial(),
               estimand_fun = "rate_ratio")
 
 odds_ratio <- function(psi1, psi0) (psi1*(1-psi0))/(psi0*(1-psi1))
 or <- rctglm(formula = Y ~ .,
-              group_indicator = A,
+              exposure_indicator = A,
               data = dat_binom,
               family = binomial,
               estimand_fun = odds_ratio)

--- a/man/rctglm_methods.Rd
+++ b/man/rctglm_methods.Rd
@@ -45,16 +45,18 @@ shortcuts to running \code{coef(x$glm)}.
 \examples{
 # Generate some data to showcase example
 n <- 100
+exposure_prob <- .5
 dat_binom <- glm_data(
   1+1.5*X1+2*A,
   X1 = rnorm(n),
-  A = rbinom(n, 1, .5),
+  A = rbinom(n, 1, exposure_prob),
   family = binomial()
 )
 
 # Fit the model
 ate <- rctglm(formula = Y ~ .,
               exposure_indicator = A,
+              exposure_prob = exposure_prob,
               data = dat_binom,
               family = binomial,
               estimand_fun = "ate")

--- a/man/rctglm_methods.Rd
+++ b/man/rctglm_methods.Rd
@@ -54,7 +54,7 @@ dat_binom <- glm_data(
 
 # Fit the model
 ate <- rctglm(formula = Y ~ .,
-              group_indicator = A,
+              exposure_indicator = A,
               data = dat_binom,
               family = binomial,
               estimand_fun = "ate")

--- a/man/rctglm_with_prognosticscore.Rd
+++ b/man/rctglm_with_prognosticscore.Rd
@@ -14,7 +14,7 @@ rctglm_with_prognosticscore(
   estimand_fun_deriv0 = NULL,
   estimand_fun_deriv1 = NULL,
   cv_variance = TRUE,
-  cv_variance_folds = 5,
+  cv_variance_folds = 10,
   ...,
   data_hist,
   prog_formula = NULL,
@@ -49,7 +49,7 @@ make the "orientation" of the \code{estimand_fun} clear.}
 "group 1" (rather than group 0) in groups defined by \code{exposure_indicator}.
 As a default, the ratio of 1's in data is used.}
 
-\item{estimand_fun}{a \code{function} with arguments \code{psi0} and \code{psi1} specifying
+\item{estimand_fun}{a \code{function} with arguments \code{psi1} and \code{psi0} specifying
 the estimand. Alternative, specify "ate" or "rate_ratio" as a \code{character}
 to use one of the default estimand functions. See
 more details in the "Estimand" section of this documentation.}
@@ -122,11 +122,12 @@ b0 <- 1
 b1 <- 1.5
 b2 <- 2
 W1 <- runif(n, min = -2, max = 2)
+exposure_prob <- .5
 
 dat_treat <- glm_data(
   b0+b1*abs(sin(W1))+b2*A,
   W1 = W1,
-  A = rbinom (n, 1, .5)
+  A = rbinom (n, 1, exposure_prob)
 )
 
 dat_notreat <- glm_data(
@@ -137,6 +138,7 @@ dat_notreat <- glm_data(
 ate <- rctglm_with_prognosticscore(
   formula = Y ~ .,
   exposure_indicator = A,
+  exposure_prob = exposure_prob,
   data = dat_treat,
   family = gaussian(),
   estimand_fun = "ate",

--- a/man/rctglm_with_prognosticscore.Rd
+++ b/man/rctglm_with_prognosticscore.Rd
@@ -8,8 +8,8 @@ rctglm_with_prognosticscore(
   formula,
   family,
   data,
-  group_indicator,
-  group_allocation_prob = NULL,
+  exposure_indicator,
+  exposure_prob = NULL,
   estimand_fun = "ate",
   estimand_fun_deriv0 = NULL,
   estimand_fun_deriv1 = NULL,
@@ -41,11 +41,12 @@ given under ‘Details’ in the \link{glm} documentation.}
     variables are taken from \code{environment(formula)},
     typically the environment from which \code{glm} is called.}
 
-\item{group_indicator}{(name of) the \emph{binary} variable in \code{data} that
+\item{exposure_indicator}{(name of) the \emph{binary} variable in \code{data} that
 identifies randomisation groups. The variable is required to be binary to
 make the "orientation" of the \code{estimand_fun} clear.}
 
-\item{group_allocation_prob}{a \code{numeric} with the probabiliy of being assigned "group 1" (rather than group 0).
+\item{exposure_prob}{a \code{numeric} with the probabiliy of being in
+"group 1" (rather than group 0) in groups defined by \code{exposure_indicator}.
 As a default, the ratio of 1's in data is used.}
 
 \item{estimand_fun}{a \code{function} with arguments \code{psi0} and \code{psi1} specifying
@@ -135,7 +136,7 @@ dat_notreat <- glm_data(
 
 ate <- rctglm_with_prognosticscore(
   formula = Y ~ .,
-  group_indicator = A,
+  exposure_indicator = A,
   data = dat_treat,
   family = gaussian(),
   estimand_fun = "ate",

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -4,7 +4,7 @@
       estimand(ate_with_cv)
     Output
         Estimate Std. Error
-      1 1.762089  0.1858713
+      1 1.762089  0.1882041
 
 ---
 
@@ -20,7 +20,7 @@
       estimand(rr)
     Output
         Estimate Std. Error
-      1 40.80363   8.430044
+      1 40.80363    8.51032
 
 # `estimand_fun_derivX` can be left as NULL or specified manually
 

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -4,7 +4,7 @@
       estimand(ate_with_cv)
     Output
         Estimate Std. Error
-      1 1.762089  0.1932432
+      1 1.762089  0.1858713
 
 ---
 
@@ -12,17 +12,16 @@
       estimand(ate_wo_cv)
     Output
         Estimate Std. Error
-      1 1.762089  0.1885315
+      1 1.762089  0.1846456
 
 # `estimand_fun_derivX` can be left as NULL or specified manually
 
     Code
       ate_auto <- withr::with_seed(42, {
-        rctglm(formula = Y ~ ., group_indicator = A, data = dat_gaus, family = gaussian,
-        estimand_fun = "ate", verbose = 1)
+        rctglm(formula = Y ~ ., exposure_indicator = A, exposure_prob = exposure_prob,
+        data = dat_gaus, family = gaussian, estimand_fun = "ate", verbose = 1)
       })
     Message
-      i Setting the group allocation probability `group_allocation_prob` as the mean of column `A` in data: 0.38
       
       -- Symbolic differentiation of estimand function --
       

--- a/tests/testthat/_snaps/rctglm_methods.md
+++ b/tests/testthat/_snaps/rctglm_methods.md
@@ -4,7 +4,7 @@
       est1
     Output
         Estimate Std. Error
-      1 1.325113   1.392244
+      1 1.325113   1.152001
 
 ---
 
@@ -12,7 +12,7 @@
       estimand(ate_wo_cvvariance)
     Output
         Estimate Std. Error
-      1 1.325113  0.9627868
+      1 1.325113  0.9875967
 
 # `coef` method works
 

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -2,8 +2,9 @@
 
     Code
       ate <- withr::with_seed(42, {
-        rctglm_with_prognosticscore(formula = Y ~ ., group_indicator = A, data = dat_treat,
-        family = gaussian(), estimand_fun = "ate", data_hist = dat_notreat, verbose = 2)
+        rctglm_with_prognosticscore(formula = Y ~ ., exposure_indicator = A,
+        exposure_prob = exposure_prob, data = dat_treat, family = gaussian(),
+        estimand_fun = "ate", data_hist = dat_notreat, verbose = 2)
       })
     Message
       
@@ -24,7 +25,6 @@
       v 3 of 3 tuning:     mod_gbt ()
       i Model with lowest RMSE: mod_gbt
       i Investigate trained learners and fitted model in `prognostic_info` list element
-      i Setting the group allocation probability `group_allocation_prob` as the mean of column `A` in data: 0.56
       
       -- Symbolic differentiation of estimand function --
       
@@ -39,9 +39,9 @@
 
     Code
       ate_wo_cvvariance <- withr::with_seed(42, {
-        rctglm_with_prognosticscore(formula = Y ~ ., group_indicator = A, data = dat_treat,
-        family = gaussian(), estimand_fun = "ate", data_hist = dat_notreat,
-        cv_variance = FALSE, verbose = 0)
+        rctglm_with_prognosticscore(formula = Y ~ ., exposure_indicator = A,
+        exposure_prob = exposure_prob, data = dat_treat, family = gaussian(),
+        estimand_fun = "ate", data_hist = dat_notreat, cv_variance = FALSE, verbose = 0)
       })
 
 ---
@@ -53,13 +53,14 @@
       Object of class rctglm_prog 
       
       Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = poisson(), 
-          data = dat_treat_pois, group_indicator = A, estimand_fun = "rate_ratio", 
-          data_hist = dat_notreat_pois, verbose = 0)
+          data = dat_treat_pois, exposure_indicator = A, exposure_prob = exposure_prob, 
+          estimand_fun = "rate_ratio", data_hist = dat_notreat_pois, 
+          verbose = 0)
       
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.609
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 64.14
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.456)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.4797)
 
 ---
 
@@ -70,11 +71,12 @@
       Object of class rctglm_prog 
       
       Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = MASS::negative.binomial(2), 
-          data = dat_treat_pois, group_indicator = A, estimand_fun = "rate_ratio", 
-          data_hist = dat_notreat_pois, verbose = 0)
+          data = dat_treat_pois, exposure_indicator = A, exposure_prob = exposure_prob, 
+          estimand_fun = "rate_ratio", data_hist = dat_notreat_pois, 
+          verbose = 0)
       
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.478
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 65.41
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.715 (0.4847)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.715 (0.5098)
 

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -60,7 +60,7 @@
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 7.981
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 58.48
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.45 (0.4797)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.327 (0.5271)
 
 ---
 
@@ -78,5 +78,5 @@
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.067
       Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 57.7
       Estimand function r: psi1/psi0
-      Estimand (r(psi_1, psi_0)) estimate (SE): 7.715 (0.5098)
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.153 (0.5114)
 

--- a/tests/testthat/test-influence_function_utils.R
+++ b/tests/testthat/test-influence_function_utils.R
@@ -3,8 +3,8 @@ test_that("`if_counterfactual_mean_glm` returns vector of evaluated IF", {
   withr::local_seed(13746)
 
   n <- 10
-  al_prob <- 0.5
-  treatindicator <- rbinom(n, size = 1, prob = al_prob)
+  exposure_prob <- 0.5
+  treatindicator <- rbinom(n, size = 1, prob = exposure_prob)
   treateffect <- 2
   mean_treatgroup <- rep(treateffect, n)
   truemean <- treatindicator * mean_treatgroup
@@ -12,9 +12,10 @@ test_that("`if_counterfactual_mean_glm` returns vector of evaluated IF", {
 
   res <- if_counterfactual_mean_glm(
     response_variable = y,
-    group_indicator = treatindicator,
+    exposure_indicator = treatindicator,
     counterfactual_pred = mean_treatgroup,
-    group_allocation_prob = al_prob
+    counterfactual_mean = treateffect,
+    exposure_prob = exposure_prob
   )
 
   expect_length(res, n)
@@ -26,8 +27,8 @@ test_that("`if_marginaleffect` returns vector of evaluated IF", {
   withr::local_seed(13746)
 
   n <- 10
-  al_prob <- 0.5
-  treatindicator <- rbinom(n, size = 1, prob = al_prob)
+  exposure_prob <- 0.5
+  treatindicator <- rbinom(n, size = 1, prob = exposure_prob)
   treateffect <- 2
   mean_treatgroup <- rep(treateffect, n)
   truemean <- treatindicator * mean_treatgroup
@@ -39,10 +40,12 @@ test_that("`if_marginaleffect` returns vector of evaluated IF", {
 
   res <- if_marginaleffect(
     response_variable = y,
-    group_indicator = treatindicator,
+    exposure_indicator = treatindicator,
+    exposure_prob = exposure_prob,
     counterfactual_pred0 = rep(0, n),
     counterfactual_pred1 = mean_treatgroup,
-    group_allocation_prob = al_prob,
+    counterfactual_mean0 = 0,
+    counterfactual_mean1 = treateffect,
     estimand_fun_deriv0 = ate_deriv0,
     estimand_fun_deriv1 = ate_deriv1
   )

--- a/tests/testthat/test-rctglm.R
+++ b/tests/testthat/test-rctglm.R
@@ -33,9 +33,10 @@ test_that("`rctglm` snapshot tests", {
   expect_snapshot(estimand(ate_wo_cv))
 
   rr <- rctglm(formula = Y ~ .,
-                        group_indicator = A,
-                        data = dat_pois,
-                        family = poisson())
+               exposure_indicator = A,
+               exposure_prob = exposure_prob,
+               data = dat_pois,
+               family = poisson())
   expect_snapshot(estimand(rr))
 })
 
@@ -223,27 +224,27 @@ test_that("`rctglm` provides error if `exposure_prob` is not a numeric between 0
   n <- 100
   exposure_prob <- 0.5
 
-    dat_gaus <- glm_data(
-      1+1.5*X1+2*A,
-      X1 = rnorm(n),
-      A = rbinom(n, 1, exposure_prob),
-      family = gaussian()
-    )
+  dat_gaus <- glm_data(
+    Y ~ 1+1.5*X1+2*A,
+    X1 = rnorm(n),
+    A = rbinom(n, 1, exposure_prob),
+    family = gaussian()
+  )
 
-    expect_error(
-      rctglm(formula = Y ~ .,
+  expect_error(
+    rctglm(formula = Y ~ .,
            exposure_indicator = A,
            exposure_prob = "1/2",
            data = dat_gaus,
            family = gaussian,
            verbose = 0)
-      )
-    expect_error(
-      rctglm(formula = Y ~ .,
-             exposure_indicator = A,
-             exposure_prob = 1.2,
-             data = dat_gaus,
-             family = gaussian,
-             verbose = 0)
-    )
+  )
+  expect_error(
+    rctglm(formula = Y ~ .,
+           exposure_indicator = A,
+           exposure_prob = 1.2,
+           data = dat_gaus,
+           family = gaussian,
+           verbose = 0)
+  )
 })

--- a/tests/testthat/test-rctglm.R
+++ b/tests/testthat/test-rctglm.R
@@ -204,3 +204,33 @@ test_that("`estimand_fun_derivX` can be left as NULL or specified manually", {
   })
   expect_equal(ate_auto$estimand, ate_man$estimand)
 })
+
+test_that("`rctglm` provides error if `exposure_prob` is not a numeric between 0 and 1", {
+  withr::local_seed(42)
+  n <- 100
+  exposure_prob <- 0.5
+
+    dat_gaus <- glm_data(
+      1+1.5*X1+2*A,
+      X1 = rnorm(n),
+      A = rbinom(n, 1, exposure_prob),
+      family = gaussian()
+    )
+
+    expect_error(
+      rctglm(formula = Y ~ .,
+           exposure_indicator = A,
+           exposure_prob = "1/2",
+           data = dat_gaus,
+           family = gaussian,
+           verbose = 0)
+      )
+    expect_error(
+      rctglm(formula = Y ~ .,
+             exposure_indicator = A,
+             exposure_prob = 1.2,
+             data = dat_gaus,
+             family = gaussian,
+             verbose = 0)
+    )
+})

--- a/tests/testthat/test-rctglm_methods.R
+++ b/tests/testthat/test-rctglm_methods.R
@@ -1,15 +1,18 @@
 test_that("`estimand` method works", {
   withr::local_seed(42)
   n <- 10
+  exposure_prob <- .5
+
   dat_gaus <- glm_data(
     1+1.5*X1+2*A,
     X1 = rnorm(n),
-    A = rbinom(n, 1, .5),
+    A = rbinom(n, 1, exposure_prob),
     family = gaussian()
   )
 
   ate <- rctglm(formula = Y ~ .,
-                group_indicator = A,
+                exposure_indicator = A,
+                exposure_prob = exposure_prob,
                 data = dat_gaus,
                 family = gaussian)
 
@@ -21,7 +24,8 @@ test_that("`estimand` method works", {
   expect_snapshot(est1)
 
   ate_wo_cvvariance <- rctglm(formula = Y ~ .,
-                              group_indicator = A,
+                              exposure_indicator = A,
+                              exposure_prob = exposure_prob,
                               data = dat_gaus,
                               family = gaussian,
                               cv_variance = FALSE)
@@ -31,15 +35,18 @@ test_that("`estimand` method works", {
 test_that("`coef` method works", {
   withr::local_seed(42)
   n <- 10
+  exposure_prob <- .5
+
   dat_gaus <- glm_data(
     1+1.5*X1+2*A,
     X1 = rnorm(n),
-    A = rbinom(n, 1, .5),
+    A = rbinom(n, 1, exposure_prob),
     family = gaussian()
   )
 
   ate <- rctglm(formula = Y ~ .,
-                group_indicator = A,
+                exposure_indicator = A,
+                exposure_prob = exposure_prob,
                 data = dat_gaus,
                 family = gaussian)
 
@@ -49,15 +56,18 @@ test_that("`coef` method works", {
 
 test_that("`print` method works", {
   n <- 10
+  exposure_prob <- .5
+
   dat_gaus <- glm_data(
     1+1.5*X1+2*A,
     X1 = rnorm(n),
-    A = rbinom(n, 1, .5),
+    A = rbinom(n, 1, exposure_prob),
     family = gaussian()
   )
 
   ate <- rctglm(formula = Y ~ .,
-                group_indicator = A,
+                exposure_indicator = A,
+                exposure_prob = exposure_prob,
                 data = dat_gaus,
                 family = gaussian)
 

--- a/tests/testthat/test-rctglm_prog_methods.R
+++ b/tests/testthat/test-rctglm_prog_methods.R
@@ -6,11 +6,12 @@ test_that("`rctglm_with_prognosticscore` returns object of correct class", {
   b1 <- 1.5
   b2 <- 2
   W1 <- runif(n, min = -2, max = 2)
+  exposure_prob <- .5
 
   dat_treat <- glm_data(
     b0+b1*abs(sin(W1))+b2*A,
     W1 = W1,
-    A = rbinom (n, 1, .5)
+    A = rbinom (n, 1, exposure_prob)
   )
   dat_notreat <- glm_data(
     b0+b1*abs(sin(W1)),
@@ -19,7 +20,8 @@ test_that("`rctglm_with_prognosticscore` returns object of correct class", {
 
   ate <- rctglm_with_prognosticscore(
     formula = Y ~ .,
-    group_indicator = A,
+    exposure_indicator = A,
+    exposure_prob = exposure_prob,
     data = dat_treat,
     family = gaussian(),
     estimand_fun = "ate",

--- a/tests/testthat/test-rctglm_utils.R
+++ b/tests/testthat/test-rctglm_utils.R
@@ -10,18 +10,18 @@ test_that("`predict_counterfactual_mean` predicts correctly", {
   mod <- glm(Y ~ X + A, data = dat)
   pred0 <- predict_counterfactual_mean(
     model = mod,
-    group_indicator_name = "A",
+    exposure_indicator_name = "A",
     group_val = 0)
 
   pred1 <- predict_counterfactual_mean(
     model = mod,
-    group_indicator_name = "A",
+    exposure_indicator_name = "A",
     group_val = 1)
 
   expect_equal(pred0, pred1 - treat_diff)
 })
 
-test_that("`predict_counterfactual_mean` gives error when `group_indicator_name` not in model or data", {
+test_that("`predict_counterfactual_mean` gives error when `exposure_indicator_name` not in model or data", {
   dat <- data.frame(
     Y = 1:10,
     X = 1:10,
@@ -33,7 +33,7 @@ test_that("`predict_counterfactual_mean` gives error when `group_indicator_name`
   expect_error(
     predict_counterfactual_mean(
       model = mod,
-      group_indicator_name = "test",
+      exposure_indicator_name = "test",
       group_val = 0),
     regexp = "is not in"
   )
@@ -50,11 +50,11 @@ test_that("`predict_counterfactual_mean` works with and without data specificati
 
   pred_nodatspec <- predict_counterfactual_mean(
     model = mod,
-    group_indicator_name = "A",
+    exposure_indicator_name = "A",
     group_val = 0)
   pred_datspec <- predict_counterfactual_mean(
     model = mod,
-    group_indicator_name = "A",
+    exposure_indicator_name = "A",
     group_val = 0,
     data = dat_fit)
 
@@ -66,7 +66,7 @@ test_that("`predict_counterfactual_mean` works with and without data specificati
   )
   pred_newdata <- predict_counterfactual_mean(
     model = mod,
-    group_indicator_name = "A",
+    exposure_indicator_name = "A",
     group_val = 0,
     data = dat_pred)
 
@@ -85,7 +85,7 @@ test_that("`predict_counterfactual_mean` predicts correctly", {
   mod <- glm(Y ~ X + A, data = dat)
   preds <- predict_counterfactual_means(
     model = mod,
-    group_indicator_name = "A")
+    exposure_indicator_name = "A")
 
   expect_s3_class(preds, "data.frame")
   expect_equal(preds$psi0, preds$psi1 - treat_diff)
@@ -122,7 +122,7 @@ test_that("`oos_fitted.values_counterfactual` snapshot test", {
 
   oos <- oos_fitted.values_counterfactual(
     data = dat,
-    group_indicator_name = "A",
+    exposure_indicator_name = "A",
     full_model.args_glm = args_glm
   )
   expect_named(oos, c("psi0", "psi1", "rowname"))

--- a/tests/testthat/test-rctglm_with_prognosticscore.R
+++ b/tests/testthat/test-rctglm_with_prognosticscore.R
@@ -6,11 +6,12 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
   b1 <- 1.5
   b2 <- 2
   W1 <- runif(n, min = -2, max = 2)
+  exposure_prob <- .5
 
   dat_treat <- glm_data(
     b0+b1*abs(sin(W1))+b2*A,
     W1 = W1,
-    A = rbinom (n, 1, .5)
+    A = rbinom (n, 1, exposure_prob)
   )
   dat_notreat <- glm_data(
     b0+b1*abs(sin(W1)),
@@ -22,7 +23,8 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
     ate <- withr::with_seed(42, {
       rctglm_with_prognosticscore(
         formula = Y ~ .,
-        group_indicator = A,
+        exposure_indicator = A,
+        exposure_prob = exposure_prob,
         data = dat_treat,
         family = gaussian(),
         estimand_fun = "ate",
@@ -39,7 +41,8 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
     ate_wo_cvvariance <- withr::with_seed(42, {
       rctglm_with_prognosticscore(
         formula = Y ~ .,
-        group_indicator = A,
+        exposure_indicator = A,
+        exposure_prob = exposure_prob,
         data = dat_treat,
         family = gaussian(),
         estimand_fun = "ate",
@@ -53,7 +56,7 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
   dat_treat_pois <- glm_data(
     b0+b1*abs(sin(W1))+b2*A,
     W1 = W1,
-    A = rbinom (n, 1, .5),
+    A = rbinom (n, 1, exposure_prob),
     family = poisson()
   )
   dat_notreat_pois <- glm_data(
@@ -65,7 +68,8 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
   rr_pois <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
       formula = Y ~ .,
-      group_indicator = A,
+      exposure_indicator = A,
+      exposure_prob = exposure_prob,
       data = dat_treat_pois,
       family = poisson(),
       estimand_fun = "rate_ratio",
@@ -77,7 +81,8 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
   rr_nb <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
       formula = Y ~ .,
-      group_indicator = A,
+      exposure_indicator = A,
+      exposure_prob = exposure_prob,
       data = dat_treat_pois,
       family = MASS::negative.binomial(2),
       estimand_fun = "rate_ratio",
@@ -95,11 +100,12 @@ test_that("`cv_variance` produces same point estimates but different SE estimate
   b1 <- 1.5
   b2 <- 2
   W1 <- runif(n, min = -2, max = 2)
+  exposure_prob <- .5
 
   dat_treat <- glm_data(
     b0+b1*abs(sin(W1))+b2*A,
     W1 = W1,
-    A = rbinom (n, 1, .5)
+    A = rbinom (n, 1, exposure_prob)
   )
   dat_notreat <- glm_data(
     b0+b1*abs(sin(W1)),
@@ -109,7 +115,8 @@ test_that("`cv_variance` produces same point estimates but different SE estimate
   ate_w_cvvariance <- withr::with_seed(42, {
       rctglm_with_prognosticscore(
         formula = Y ~ .,
-        group_indicator = A,
+        exposure_indicator = A,
+        exposure_prob = exposure_prob,
         data = dat_treat,
         family = gaussian(),
         estimand_fun = "ate",
@@ -120,7 +127,8 @@ test_that("`cv_variance` produces same point estimates but different SE estimate
   ate_wo_cvvariance <- withr::with_seed(42, {
       rctglm_with_prognosticscore(
         formula = Y ~ .,
-        group_indicator = A,
+        exposure_indicator = A,
+        exposure_prob = exposure_prob,
         data = dat_treat,
         family = gaussian(),
         estimand_fun = "ate",
@@ -149,11 +157,12 @@ test_that("`prog_formula` manual specification consistent with default behavior"
   b1 <- 1.5
   b2 <- 2
   W1 <- runif(n, min = -2, max = 2)
+  exposure_prob <- .5
 
   dat_treat <- glm_data(
     b0+b1*abs(sin(W1))+b2*A,
     W1 = W1,
-    A = rbinom (n, 1, .5)
+    A = rbinom (n, 1, exposure_prob)
   )
   dat_notreat <- glm_data(
     b0+b1*abs(sin(W1)),
@@ -164,7 +173,8 @@ test_that("`prog_formula` manual specification consistent with default behavior"
   ate_wo_prog_formula <- withr::with_seed(42, {
       rctglm_with_prognosticscore(
         formula = Y ~ .,
-        group_indicator = A,
+        exposure_indicator = A,
+        exposure_prob = exposure_prob,
         data = dat_treat,
         family = gaussian(),
         estimand_fun = "ate",
@@ -175,7 +185,8 @@ test_that("`prog_formula` manual specification consistent with default behavior"
   ate_w_prog_formula <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
       formula = Y ~ .,
-      group_indicator = A,
+      exposure_indicator = A,
+      exposure_prob = exposure_prob,
       data = dat_treat,
       family = gaussian(),
       estimand_fun = "ate",

--- a/vignettes/more-details.Rmd
+++ b/vignettes/more-details.Rmd
@@ -42,7 +42,7 @@ b2 <- 2
 dat_pois <- glm_data(
   b0+b1*sin(W)^2+b2*A,
   W = runif(n, min = -2, max = 2),
-  A = rbinom(n, 1, .5),
+  A = rbinom(n, 1, 1/2),
   family = poisson(link = "log") # Default value
 )
 ```
@@ -58,7 +58,8 @@ Built in is the ATE and rate ratio, which can be specified with character string
 ```{r rate-ratio-run-show}
 rate_ratio <- rctglm(
   formula = Y ~ A + W,
-  group_indicator = A,
+  exposure_indicator = A,
+  exposure_prob = 1/2,
   data = dat_pois,
   family = "poisson",
   estimand_fun = "rate_ratio")
@@ -78,7 +79,8 @@ nonsense_estimand_fun <- function(psi1, psi0) {
 
 nonsense_estimand <- rctglm(
   formula = Y ~ A * W,
-  group_indicator = A,
+  exposure_indicator = A,
+  exposure_prob = 1/2,
   data = dat_pois,
   family = poisson(),
   estimand_fun = nonsense_estimand_fun,
@@ -126,7 +128,7 @@ W_sim <- runif(n, min = -2, max = 2)
 dat_treat <- glm_data(
   b0+b1*abs(sin(W))+b2*A,
   W = W_sim,
-  A = rbinom (n, 1, .5)
+  A = rbinom (n, 1, 1/2)
 )
 
 dat_notreat <- glm_data(
@@ -158,7 +160,8 @@ learners <- list(
 
 model_own_learners <- rctglm_with_prognosticscore(
   formula = Y ~ A * W,
-  group_indicator = A,
+  exposure_indicator = A,
+  exposure_prob = 1/2,
   data = dat_treat,
   family = gaussian(),
   data_hist = dat_notreat,


### PR DESCRIPTION
Specifically to `exposure_indicator` and `exposure_prob`.