### PR TITLE
feature: `cv_variance` changed to default FALSE (like `glm` robust estimation is off by default)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     tidyselect,
     tune,
     utils,
-    withr,
     workflowsets,
     xgboost,
     yardstick
@@ -35,7 +34,8 @@ Suggests:
     MASS,
     ranger,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/R/rctglm.R
+++ b/R/rctglm.R
@@ -138,7 +138,7 @@ rctglm <- function(formula,
                    data,
                    estimand_fun = "ate",
                    estimand_fun_deriv0 = NULL, estimand_fun_deriv1 = NULL,
-                   cv_variance = TRUE,
+                   cv_variance = FALSE,
                    cv_variance_folds = 10,
                    verbose = options::opt("verbose"),
                    ...

--- a/R/rctglm_with_prognosticscore.R
+++ b/R/rctglm_with_prognosticscore.R
@@ -76,7 +76,7 @@ rctglm_with_prognosticscore <- function(
     exposure_prob = NULL,
     estimand_fun = "ate",
     estimand_fun_deriv0 = NULL, estimand_fun_deriv1 = NULL,
-    cv_variance = TRUE,
+    cv_variance = FALSE,
     cv_variance_folds = 10,
     ...,
     data_hist,

--- a/man/rctglm.Rd
+++ b/man/rctglm.Rd
@@ -14,7 +14,7 @@ rctglm(
   estimand_fun = "ate",
   estimand_fun_deriv0 = NULL,
   estimand_fun_deriv1 = NULL,
-  cv_variance = TRUE,
+  cv_variance = FALSE,
   cv_variance_folds = 10,
   verbose = options::opt("verbose"),
   ...

--- a/man/rctglm_with_prognosticscore.Rd
+++ b/man/rctglm_with_prognosticscore.Rd
@@ -13,7 +13,7 @@ rctglm_with_prognosticscore(
   estimand_fun = "ate",
   estimand_fun_deriv0 = NULL,
   estimand_fun_deriv1 = NULL,
-  cv_variance = TRUE,
+  cv_variance = FALSE,
   cv_variance_folds = 10,
   ...,
   data_hist,

--- a/tests/testthat/_snaps/rctglm.md
+++ b/tests/testthat/_snaps/rctglm.md
@@ -17,17 +17,26 @@
 ---
 
     Code
-      estimand(rr)
+      estimand(rr_with_cv)
     Output
         Estimate Std. Error
       1 40.80363    8.51032
+
+---
+
+    Code
+      estimand(rr_wo_cv)
+    Output
+        Estimate Std. Error
+      1 40.80363    8.55476
 
 # `estimand_fun_derivX` can be left as NULL or specified manually
 
     Code
       ate_auto <- withr::with_seed(42, {
         rctglm(formula = Y ~ ., exposure_indicator = A, exposure_prob = exposure_prob,
-        data = dat_gaus, family = gaussian, estimand_fun = "ate", verbose = 1)
+        data = dat_gaus, family = gaussian, estimand_fun = "ate", cv_variance = FALSE,
+        verbose = 1)
       })
     Message
       

--- a/tests/testthat/_snaps/rctglm_methods.md
+++ b/tests/testthat/_snaps/rctglm_methods.md
@@ -1,19 +1,3 @@
-# `estimand` method works
-
-    Code
-      est1
-    Output
-        Estimate Std. Error
-      1 1.325113   1.152001
-
----
-
-    Code
-      estimand(ate_wo_cvvariance)
-    Output
-        Estimate Std. Error
-      1 1.325113  0.9875967
-
 # `coef` method works
 
     Code

--- a/tests/testthat/_snaps/rctglm_with_prognosticscore.md
+++ b/tests/testthat/_snaps/rctglm_with_prognosticscore.md
@@ -4,7 +4,7 @@
       ate <- withr::with_seed(42, {
         rctglm_with_prognosticscore(formula = Y ~ ., exposure_indicator = A,
         exposure_prob = exposure_prob, data = dat_treat, family = gaussian(),
-        estimand_fun = "ate", data_hist = dat_notreat, verbose = 2)
+        estimand_fun = "ate", data_hist = dat_notreat, cv_variance = TRUE, verbose = 2)
       })
     Message
       
@@ -47,14 +47,32 @@
 ---
 
     Code
-      rr_pois
+      rr_pois_wo_cvvariance
     Output
       
       Object of class rctglm_prog 
       
       Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = poisson(), 
           data = dat_treat_pois, exposure_indicator = A, exposure_prob = exposure_prob, 
-          estimand_fun = "rate_ratio", data_hist = dat_notreat_pois, 
+          estimand_fun = "rate_ratio", cv_variance = FALSE, data_hist = dat_notreat_pois, 
+          verbose = 0)
+      
+      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 7.981
+      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 58.48
+      Estimand function r: psi1/psi0
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.327 (0.518)
+
+---
+
+    Code
+      rr_pois_with_cvvariance
+    Output
+      
+      Object of class rctglm_prog 
+      
+      Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = poisson(), 
+          data = dat_treat_pois, exposure_indicator = A, exposure_prob = exposure_prob, 
+          estimand_fun = "rate_ratio", cv_variance = TRUE, data_hist = dat_notreat_pois, 
           verbose = 0)
       
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 7.981
@@ -65,14 +83,32 @@
 ---
 
     Code
-      rr_nb
+      rr_nb_wo_cvvariance
     Output
       
       Object of class rctglm_prog 
       
       Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = MASS::negative.binomial(2), 
           data = dat_treat_pois, exposure_indicator = A, exposure_prob = exposure_prob, 
-          estimand_fun = "rate_ratio", data_hist = dat_notreat_pois, 
+          estimand_fun = "rate_ratio", cv_variance = FALSE, data_hist = dat_notreat_pois, 
+          verbose = 0)
+      
+      Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.067
+      Counterfactual control mean (psi_1=E[Y|X, A=1]) estimate: 57.7
+      Estimand function r: psi1/psi0
+      Estimand (r(psi_1, psi_0)) estimate (SE): 7.153 (0.5005)
+
+---
+
+    Code
+      rr_nb_with_cvvariance
+    Output
+      
+      Object of class rctglm_prog 
+      
+      Call:  rctglm_with_prognosticscore(formula = Y ~ ., family = MASS::negative.binomial(2), 
+          data = dat_treat_pois, exposure_indicator = A, exposure_prob = exposure_prob, 
+          estimand_fun = "rate_ratio", cv_variance = TRUE, data_hist = dat_notreat_pois, 
           verbose = 0)
       
       Counterfactual control mean (psi_0=E[Y|X, A=0]) estimate: 8.067

--- a/tests/testthat/test-rctglm_methods.R
+++ b/tests/testthat/test-rctglm_methods.R
@@ -14,22 +14,14 @@ test_that("`estimand` method works", {
                 exposure_indicator = A,
                 exposure_prob = exposure_prob,
                 data = dat_gaus,
-                family = gaussian)
+                family = gaussian,
+                cv_variance = FALSE)
 
   est1 <- estimand(ate)
   est2 <- est(ate)
   expect_equal(est1, est2)
   expect_equal(est2, ate$estimand)
   expect_named(est1, c("Estimate", "Std. Error"))
-  expect_snapshot(est1)
-
-  ate_wo_cvvariance <- rctglm(formula = Y ~ .,
-                              exposure_indicator = A,
-                              exposure_prob = exposure_prob,
-                              data = dat_gaus,
-                              family = gaussian,
-                              cv_variance = FALSE)
-  expect_snapshot(estimand(ate_wo_cvvariance))
 })
 
 test_that("`coef` method works", {
@@ -48,7 +40,8 @@ test_that("`coef` method works", {
                 exposure_indicator = A,
                 exposure_prob = exposure_prob,
                 data = dat_gaus,
-                family = gaussian)
+                family = gaussian,
+                cv_variance = FALSE)
 
   expect_equal(coef(ate$glm), coef(ate))
   expect_snapshot(coef(ate))
@@ -69,7 +62,8 @@ test_that("`print` method works", {
                 exposure_indicator = A,
                 exposure_prob = exposure_prob,
                 data = dat_gaus,
-                family = gaussian)
+                family = gaussian,
+                cv_variance = FALSE)
 
   expect_output(print(ate))
 })

--- a/tests/testthat/test-rctglm_prog_methods.R
+++ b/tests/testthat/test-rctglm_prog_methods.R
@@ -25,7 +25,8 @@ test_that("`rctglm_with_prognosticscore` returns object of correct class", {
     data = dat_treat,
     family = gaussian(),
     estimand_fun = "ate",
-    data_hist = dat_notreat)
+    data_hist = dat_notreat,
+    cv_variance = FALSE)
 
   expect_equal(ate$prognostic_info, prog(ate))
   expect_snapshot(prog(ate),

--- a/tests/testthat/test-rctglm_with_prognosticscore.R
+++ b/tests/testthat/test-rctglm_with_prognosticscore.R
@@ -7,7 +7,7 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
   b2 <- 2
   W1 <- runif(n, min = -2, max = 2)
   exposure_prob <- .5
-  
+
   dat_treat <- glm_data(
     Y ~ b0+b1*abs(sin(W1))+b2*A,
     W1 = W1,
@@ -29,6 +29,7 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
         family = gaussian(),
         estimand_fun = "ate",
         data_hist = dat_notreat,
+        cv_variance = TRUE,
         verbose = 2)
     })
   },
@@ -70,7 +71,7 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
     family = poisson()
   )
 
-  rr_pois <- withr::with_seed(42, {
+  rr_pois_wo_cvvariance <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
       formula = Y ~ .,
       exposure_indicator = A,
@@ -79,11 +80,26 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
       family = poisson(),
       estimand_fun = "rate_ratio",
       data_hist = dat_notreat_pois,
+      cv_variance = FALSE,
       verbose = 0)
   })
-  expect_snapshot(rr_pois)
+  expect_snapshot(rr_pois_wo_cvvariance)
 
-  rr_nb <- withr::with_seed(42, {
+  rr_pois_with_cvvariance <- withr::with_seed(42, {
+    rctglm_with_prognosticscore(
+      formula = Y ~ .,
+      exposure_indicator = A,
+      exposure_prob = exposure_prob,
+      data = dat_treat_pois,
+      family = poisson(),
+      estimand_fun = "rate_ratio",
+      data_hist = dat_notreat_pois,
+      cv_variance = TRUE,
+      verbose = 0)
+  })
+  expect_snapshot(rr_pois_with_cvvariance)
+
+  rr_nb_wo_cvvariance <- withr::with_seed(42, {
     rctglm_with_prognosticscore(
       formula = Y ~ .,
       exposure_indicator = A,
@@ -92,9 +108,24 @@ test_that("`rctglm_with_prognosticscore` snapshot tests", {
       family = MASS::negative.binomial(2),
       estimand_fun = "rate_ratio",
       data_hist = dat_notreat_pois,
+      cv_variance = FALSE,
       verbose = 0)
   })
-  expect_snapshot(rr_nb)
+  expect_snapshot(rr_nb_wo_cvvariance)
+
+  rr_nb_with_cvvariance <- withr::with_seed(42, {
+    rctglm_with_prognosticscore(
+      formula = Y ~ .,
+      exposure_indicator = A,
+      exposure_prob = exposure_prob,
+      data = dat_treat_pois,
+      family = MASS::negative.binomial(2),
+      estimand_fun = "rate_ratio",
+      data_hist = dat_notreat_pois,
+      cv_variance = TRUE,
+      verbose = 0)
+  })
+  expect_snapshot(rr_nb_with_cvvariance)
 })
 
 test_that("`cv_variance` produces same point estimates but different SE estimates", {
@@ -184,6 +215,7 @@ test_that("`prog_formula` manual specification consistent with default behavior"
         family = gaussian(),
         estimand_fun = "ate",
         data_hist = dat_notreat,
+        cv_variance = FALSE,
         verbose = 2)
     })
 
@@ -196,6 +228,7 @@ test_that("`prog_formula` manual specification consistent with default behavior"
       family = gaussian(),
       estimand_fun = "ate",
       data_hist = dat_notreat,
+      cv_variance = FALSE,
       prog_formula = "Y ~ W1")
   })
 


### PR DESCRIPTION
Also added and changed tests to always specify this argument, so test results do not change with default value change.